### PR TITLE
Don't upgrade pip/setuptools/wheel each install

### DIFF
--- a/app/run_clarity.ps1
+++ b/app/run_clarity.ps1
@@ -78,10 +78,8 @@ if (Test-Path -Path "venv") {
     LogWrite "Creating virtual environment."
     & $PythonInstallPath -m venv venv
 	& .\venv\Scripts\activate
-    LogWrite "Updating pip and installation dependencies."
-    & .\venv\Scripts\python.exe -m pip install --upgrade pip setuptools wheel --quiet
     LogWrite "Installing dqxclarity dependencies."
-    & .\venv\Scripts\pip.exe install -r requirements.txt --quiet
+    & .\venv\Scripts\pip.exe install --disable-pip-version-check -r requirements.txt --quiet --use-pep517
 }
 
 LogWrite "Python install location: $PythonInstallPath"


### PR DESCRIPTION
User seeing issues with upgrading pip/setup tools:

```
Updating pip and installation dependencies.
    WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\setuptools-65.
5.0.dist-info due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\setuptools-65.5.0.
dist-info due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\pip-22.3.1.dist-in
fo due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\setuptools-65.5.0.
dist-info due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\pip-22.3.1.dist-in
fo due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\setuptools-65.5.0.
dist-info due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\pip-22.3.1.dist-in
fo due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\setuptools-65.5.0.
dist-info due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\pip-22.3.1.dist-in
fo due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\setuptools-65.5.0.
dist-info due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\pip-22.3.1.dist-in
fo due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\setuptools-65.5.0.
dist-info due to invalid metadata entry 'name'
WARNING: Skipping J:\Games\Windows PC\Dragon Quest X (Windows)\Clarity for DQX\venv\Lib\site-packages\pip-22.3.1.dist-in
fo due to invalid metadata entry 'name'
Installing dqxclarity dependencies.
```

Instead of doing this each run, just install the packages with `--disable-pip-version-check`. Also, add `--use-pep517` to installation. Clarity installs a few language packages that have not been updated in a while, so they haven't converted to using toml files for their installs.