### PR TITLE
Update gha release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,14 +1,16 @@
 ---
-name: "generate-release"
+name: "build-release-zip"
 
 on:
   push:
     branches:
       - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  generate-release:
-    name: 'Generate release'
+  build-release-zip:
+    name: 'build-release-zip'
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
@@ -31,7 +33,8 @@ jobs:
       - name: Update GITHUB_ENV env
         run: |
           echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-          echo "CURRENT_TAG=`git describe --tags $(git rev-list --tags) | grep -v dev | head -n1 | cut -d"-" -f1`" >> $GITHUB_ENV
+          echo "CURRENT_TAG=`git describe --always --tags $(git rev-list --tags) | grep -v 'dev' | grep -E '^v' | head -n1 | cut -d"-" -f1`" >> $GITHUB_ENV
+          echo "NEW_TAG=`echo ${GITHUB_REF} | cut -d"/" -f3`" >> $GITHUB_ENV
 
       - name: Bump version.update
         if: startsWith(github.ref, 'refs/tags/v')
@@ -77,6 +80,27 @@ jobs:
           name: 'Dev Build: ${{ env.CURRENT_TAG }}-dev'
           body: "This is a pre-release build! You don't want to download this!"
 
+      - name: Commit version.update to main
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: stefanzweifel/git-auto-commit-action@v4
+        id: auto-commit-action
+        with:
+          commit_message: 'Automated bump of version.update'
+          file_pattern: 'version.update'
+          branch: main
+
+      # probably a better way to do this. big no-no to move an existing tag,
+      # but there's no malicious stuff going on here. we just want the tag
+      # to include the updated version.update file and we're doing it strictly
+      # in CI. the tag is what triggers these steps and I don't want to manually
+      # update the version.update file before pushing the tag.
+      - name: Include previous commit in new tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          git checkout ${{ steps.auto-commit-action.outputs.commit_hash }}
+          git tag -f $NEW_TAG
+          git push --force origin $NEW_TAG
+
       - name: Creating prod release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
@@ -85,5 +109,5 @@ jobs:
           prerelease: false
           draft: false
           tag_name: ${{ github.ref }}
-          name: 'Release: ${{ github.ref }}'
+          name: 'Release: ${{ env.NEW_TAG }}'  # github.ref does not trim refs/tags/ when used here
           generate_release_notes: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-release-zip:
-    name: 'build-release-zip'
+    name: Build release zip
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,11 +2,13 @@
 
 Releases are performed through Github Action workflows.
 
-- Ensure all changes to be released are in the `main` branch
-    - You can do this by opening a PR to merge `dev` -> `main`
-- Once PR is merged, ensure you have pulled down the latest `main` branch
+- All changes expected to be released should exist in `main`
+- Ensure you have pulled down the latest `main` branch
     - `git pull origin main`
-- Create the new tag (please prepend the tag with "v")
+- Create a new tag (make sure to prepend the tag with "v")
     - `git tag <version>` (ex: `git tag v4.0.0`)
 - Push the tag up
     - `git push origin <version>` (ex: `git push origin v4.0.0`)
+- This will trigger a Github Action named `build-release-zip`
+- After a minute or two, you'll see a new release generated with the tag that was pushed up
+- Either manually download the DAT/IDX file from the previous release and upload it to the new release, or navigate to the `etps` repository and kick off a manual workflow run to move the DAT/IDX to the new release


### PR DESCRIPTION
The idea here is:

- Any commits to main will build a "dev" version of the current tag
  - If we are on tag v4.0.0, a commit to main will make a pre-release and tag for v4.0.0-dev
  - This was changed from automatically converting to v4.1.0 because this assumes the next tag already. We don't know what the next version will immediately be.
- Any existing assets attached to the dev release will be deleted and the latest zip will be attached instead
- When a new tag is pushed to the repository, the same tag (minus the v) will be written to the version.update file and committed
- We move the tag to the commit that made the change to version.updateso so that the tag includes the version bump
- This also kicks off a new official release with the tag that was pushed

It's similar to before, but there is no more PR -> dev -> main workflow. It's just PR -> main. main will act as dev until it has been tagged, which will then turn into a release. PRs shouldn't make their way into main without testing and there shouldn't be any direct pushes to main without going through a PR first.