### PR TITLE
chore: Ship blank source code zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# there are too many users who manage to download the source code zip
+# instead of the deliverable zip asset that's shipped. this tells github
+# to generate a blank source code zip.
+* export-ignore


### PR DESCRIPTION
Tell github to not run an archive on the entire repo when generating a source code zip.