### PR TITLE
Don't call direct memory operations and just import the class.

### DIFF
--- a/app/clarity.py
+++ b/app/clarity.py
@@ -1,12 +1,8 @@
 from common.db_ops import sql_read, sql_write
 from common.errors import MemoryReadError
-from common.lib import (
-    get_project_root,
-    is_dqx_process_running,
-    merge_jsons,
-    setup_logging,
-)
-from common.memory import pattern_scan, read_bytes, read_string, write_string
+from common.lib import get_project_root, merge_jsons, setup_logging
+from common.memory import MemWriter
+from common.process import is_dqx_process_running
 from common.signatures import (
     comm_name_pattern_1,
     comm_name_pattern_2,
@@ -29,16 +25,17 @@ import traceback
 def scan_for_player_names():
     """Scans for addresses that are related to a specific pattern to translate
     player names."""
-    if addresses := pattern_scan(pattern=player_name_pattern, return_multiple=True):
+    writer = MemWriter()
+    if addresses := writer.pattern_scan(pattern=player_name_pattern, return_multiple=True):
         for address in addresses:
             player_name_address = address + 48  # len of player_name_pattern - 1
             try:
-                ja_name = read_string(player_name_address)
+                ja_name = writer.read_string(player_name_address)
                 en_name = convert_into_eng(ja_name)
                 if en_name != ja_name:
                     # we use a leading x04 byte here as the game assumes all names that start
                     # with an english letter are GMs.
-                    write_string(player_name_address, "\x04" + en_name)
+                    writer.write_string(player_name_address, "\x04" + en_name)
             except UnicodeDecodeError:
                 continue
             except Exception:
@@ -49,12 +46,13 @@ def scan_for_player_names():
 def scan_for_comm_names():
     """Scans for addresses that are related to a specific pattern to translate
     player names in the comms window."""
+    writer = MemWriter()
     comm_addresses = []
 
     # the comm names were found to use two patterns. the first set we can use as is, the second set
     # we need to jump ahead one byte before we r/w.
-    comm_names_1 = pattern_scan(pattern=comm_name_pattern_1, use_regex=True, return_multiple=True)
-    comm_names_2 = pattern_scan(pattern=comm_name_pattern_2, use_regex=True, return_multiple=True)
+    comm_names_1 = writer.pattern_scan(pattern=comm_name_pattern_1, use_regex=True, return_multiple=True)
+    comm_names_2 = writer.pattern_scan(pattern=comm_name_pattern_2, use_regex=True, return_multiple=True)
 
     if comm_names_1:
         for address in comm_names_1:
@@ -66,10 +64,10 @@ def scan_for_comm_names():
 
     for address in comm_addresses:
         try:
-            ja_name = read_string(address)
+            ja_name = writer.read_string(address)
             en_name = convert_into_eng(ja_name)
             if en_name != ja_name:
-                write_string(address, "\x04" + en_name)
+                writer.write_string(address, "\x04" + en_name)
         except UnicodeDecodeError:
             continue
         except TypeError:
@@ -82,21 +80,22 @@ def scan_for_comm_names():
 def scan_for_sibling_name():
     """Scans for addresses that are related to a specific pattern to translate
     the player's sibling name."""
-    if address := pattern_scan(pattern=sibling_name_pattern):
+    writer = MemWriter()
+    if address := writer.pattern_scan(pattern=sibling_name_pattern):
         sibling_address = address + 51  # len of num of (sibling_name_pattern - 1)
         player_address = address - 21  # start of sibling_name_pattern - 21 (jump to player name)
         try:
-            ja_sibling_name = read_string(sibling_address)
-            ja_player_name = read_string(player_address)
+            ja_sibling_name = writer.read_string(sibling_address)
+            ja_player_name = writer.read_string(player_address)
 
             en_sibling_name = convert_into_eng(ja_sibling_name)
             en_player_name = convert_into_eng(ja_player_name)
 
             if en_sibling_name != ja_sibling_name:
-                write_string(sibling_address, "\x04" + en_sibling_name)
+                writer.write_string(sibling_address, "\x04" + en_sibling_name)
 
             if en_player_name != ja_player_name:
-                write_string(player_address, "\x04" + en_player_name)
+                writer.write_string(player_address, "\x04" + en_player_name)
         except UnicodeDecodeError:
             pass
         except Exception:
@@ -106,14 +105,15 @@ def scan_for_sibling_name():
 def scan_for_concierge_names():
     """Scans for addresses that are related to a specific pattern to translate
     concierge names."""
-    if addresses := pattern_scan(pattern=concierge_name_pattern, return_multiple=True):
+    writer = MemWriter()
+    if addresses := writer.pattern_scan(pattern=concierge_name_pattern, return_multiple=True):
         for address in addresses:
             name_address = address + 12  # jump to name
             try:
-                ja_name = read_string(name_address)
+                ja_name = writer.read_string(name_address)
                 en_name = convert_into_eng(ja_name)
                 if en_name != ja_name:
-                    write_string(name_address, "\x04" + en_name)
+                    writer.write_string(name_address, "\x04" + en_name)
             except UnicodeDecodeError:
                 pass
             except Exception:
@@ -124,6 +124,7 @@ def scan_for_concierge_names():
 def scan_for_npc_names():
     """Scan to look for NPC names, monster names and names above your party
     member's heads and translates them into English."""
+    writer = MemWriter()
     misc_files = get_project_root("misc_files")
     translated_npc_names = merge_jsons([
         f"{misc_files}/smldt_msg_pkg_NPC_DB.win32.json",
@@ -131,9 +132,9 @@ def scan_for_npc_names():
     ])
     translated_monster_names = merge_jsons([f"{misc_files}/subPackage02Client.win32.json"])
 
-    if npc_list := pattern_scan(pattern=npc_monster_pattern, return_multiple=True):
+    if npc_list := writer.pattern_scan(pattern=npc_monster_pattern, return_multiple=True):
         for address in npc_list:
-            npc_type = read_bytes(address + 36, 2)
+            npc_type = writer.read_bytes(address + 36, 2)
             if npc_type == b"\x68\x0C":
                 data = "NPC"
                 translated_names = translated_npc_names
@@ -146,21 +147,21 @@ def scan_for_npc_names():
                 continue
 
             name_addr = address + 48  # jump to name
-            name = read_string(name_addr)
+            name = writer.read_string(name_addr)
 
             if data == "NPC" or data == "MONSTER":
                 if name in translated_names:
                     value = translated_names.get(name)
                     if value:
                         try:
-                            write_string(name_addr, value)
+                            writer.write_string(name_addr, value)
                         except Exception as e:
                             log.debug(f"Failed to write {data}. {e}")
             elif data == "AI_NAME":
                 en_name = convert_into_eng(name)
                 if en_name != name:
                     try:
-                        write_string(name_addr, "\x04" + en_name)
+                        writer.write_string(name_addr, "\x04" + en_name)
                     except Exception as e:
                         log.debug(f"Failed to write {data}. {e}")
 
@@ -168,14 +169,15 @@ def scan_for_npc_names():
 def scan_for_menu_ai_names():
     """Scans for addresses that are related to a specific pattern to translate
     party member names in the party member panel."""
-    if addresses := pattern_scan(pattern=menu_ai_name_pattern, return_multiple=True):
+    writer = MemWriter()
+    if addresses := writer.pattern_scan(pattern=menu_ai_name_pattern, return_multiple=True):
         for address in addresses:
             name_address = address + 57
             try:
-                ja_name = read_string(name_address)
+                ja_name = writer.read_string(name_address)
                 en_name = convert_into_eng(ja_name)
                 if en_name != ja_name:
-                    write_string(name_address, en_name)
+                    writer.write_string(name_address, en_name)
             except UnicodeDecodeError:
                 pass
             except Exception:
@@ -195,24 +197,25 @@ def loop_scan_for_walkthrough():
     translator = Translate()
 
     try:
+        writer = MemWriter()
         pattern = re.compile(walkthrough_pattern[0:55])  # 55 sliced characters == 16 bytes
         while True:
-            if address := pattern_scan(pattern=walkthrough_pattern):
+            if address := writer.pattern_scan(pattern=walkthrough_pattern):
                 prev_text = ""
                 while True:
                     # check if the address is still valid by validating the pattern.
                     # if not, we'll re-scan for it.
-                    verify = read_bytes(address, 16)
+                    verify = writer.read_bytes(address, 16)
                     if not pattern.match(verify):
                         log.debug("Lost walkthrough pattern. Starting scan again.")
                         break
-                    if text := read_string(address + 16):
+                    if text := writer.read_string(address + 16):
                         if text != prev_text:
                             prev_text = text
                             if detect_lang(text):
                                 result = sql_read(text=text, table="walkthrough", language=translator.region_code)
                                 if result:
-                                    write_string(address + 16, result)
+                                    writer.write_string(address + 16, result)
                                 else:
                                     translated_text = translator.sanitize_and_translate(
                                         text=text,
@@ -227,7 +230,7 @@ def loop_scan_for_walkthrough():
                                             table="walkthrough",
                                             language=translator.region_code
                                         )
-                                        write_string(address + 16, translated_text)
+                                        writer.write_string(address + 16, translated_text)
                                     except Exception:
                                         log.exception("Failed to write walkthrough.")
                         else:

--- a/app/common/lib.py
+++ b/app/common/lib.py
@@ -2,14 +2,10 @@ from locale import getencoding
 from loguru import logger as log
 from pathlib import Path
 
-import ctypes
-import datetime
 import json
 import logging
 import os
 import shutil
-import subprocess
-import time
 
 
 def read_json_file(file):
@@ -105,46 +101,3 @@ def encode_to_utf8(string: str):
     """Encodes a string of the current machine's encoding to utf-8."""
     current_locale = getencoding()
     return string.encode(current_locale).decode(current_locale).encode()
-
-
-def is_dqx_process_running():
-    """Returns True if DQX is currently running."""
-    # https://stackoverflow.com/a/29275361
-    # will only work on windows.
-    call = 'TASKLIST', '/FI', 'imagename eq DQXGame.exe'
-    output = decode_to_utf8(byte_str=subprocess.check_output(call))
-
-    # no matter what language we parse, the process name is always in latin characters
-    if "DQXGame.exe" in output:
-        return True
-
-    return False
-
-
-def check_if_running_as_admin():
-    """Check if the user is running this script as an admin.
-
-    If not, return False.
-    """
-    # will only work on windows.
-    is_admin = ctypes.windll.shell32.IsUserAnAdmin()
-    if is_admin == 1:
-        return True
-    return False
-
-
-def wait_for_dqx_to_launch() -> bool:
-    """Scans for the DQXGame.exe process."""
-    log.info("Launch DQX and log in to continue.")
-    if is_dqx_process_running():
-        log.success("DQXGame.exe found.")
-        return
-    while not is_dqx_process_running():
-        time.sleep(0.25)
-    from common.memory import pattern_scan
-    from common.signatures import notice_string
-    log.success("DQXGame.exe found. Make sure you're on the \"Important notice\" screen.")
-    while True:
-        if pattern_scan(pattern=notice_string):
-            log.success("\"Important notice\" screen found.")
-            return

--- a/app/common/process.py
+++ b/app/common/process.py
@@ -1,0 +1,50 @@
+from common.lib import decode_to_utf8
+from common.memory import MemWriter
+from common.signatures import notice_string
+from loguru import logger as log
+
+import ctypes
+import subprocess
+import time
+
+
+def is_dqx_process_running():
+    """Returns True if DQX is currently running."""
+    # https://stackoverflow.com/a/29275361
+    # will only work on windows.
+    call = 'TASKLIST', '/FI', 'imagename eq DQXGame.exe'
+    output = decode_to_utf8(byte_str=subprocess.check_output(call))
+
+    # no matter what language we parse, the process name is always in latin characters
+    if "DQXGame.exe" in output:
+        return True
+
+    return False
+
+
+def check_if_running_as_admin():
+    """Check if the user is running this script as an admin.
+
+    If not, return False.
+    """
+    # will only work on windows.
+    is_admin = ctypes.windll.shell32.IsUserAnAdmin()
+    if is_admin == 1:
+        return True
+    return False
+
+
+def wait_for_dqx_to_launch() -> bool:
+    """Scans for the DQXGame.exe process."""
+    log.info("Launch DQX and log in to continue.")
+    if is_dqx_process_running():
+        log.success("DQXGame.exe found.")
+        return
+    while not is_dqx_process_running():
+        time.sleep(0.25)
+    log.success("DQXGame.exe found. Make sure you're on the \"Important notice\" screen.")
+    writer = MemWriter()
+    while True:
+        if writer.pattern_scan(pattern=notice_string):
+            log.success("\"Important notice\" screen found.")
+            return

--- a/app/common/update.py
+++ b/app/common/update.py
@@ -11,11 +11,8 @@ from common.constants import (
     GITHUB_CUSTOM_TRANSLATIONS_ZIP_URL,
 )
 from common.errors import message_box
-from common.lib import (
-    check_if_running_as_admin,
-    get_project_root,
-    is_dqx_process_running,
-)
+from common.lib import get_project_root
+from common.process import check_if_running_as_admin, is_dqx_process_running
 from common.translate import load_user_config, update_user_config
 from io import BytesIO
 from loguru import logger as log

--- a/app/hooking/dialog.py
+++ b/app/hooking/dialog.py
@@ -1,6 +1,6 @@
 from common.db_ops import sql_read, sql_write
 from common.lib import encode_to_utf8
-from common.memory import read_string, unpack_to_int, write_string
+from common.memory import MemWriter
 from common.translate import detect_lang, Translate
 from json import dumps
 
@@ -14,21 +14,22 @@ class Dialog:
     region = translator.region_code
 
     def __init__(self, address, debug=False):
+        writer = MemWriter()
         if debug:
             self.address = address
         else:
-            self.address = unpack_to_int(address)
+            self.address = writer.unpack_to_int(address)
 
-        self.text = read_string(self.address)
+        self.text = writer.read_string(self.address)
         if detect_lang(self.text):
             db_result = self.__read_db(self.text)
             if db_result:
-                write_string(self.address, text=db_result)
+                writer.write_string(self.address, text=db_result)
             else:
                 translated_text = self.__translate(self.text)
                 if translated_text:
                     self.__write_db(source_text=self.text, translated_text=translated_text)
-                    write_string(self.address, text=translated_text)
+                    writer.write_string(self.address, text=translated_text)
 
 
     def __read_db(self, text: str):

--- a/app/hooking/player.py
+++ b/app/hooking/player.py
@@ -1,5 +1,5 @@
 from common.lib import encode_to_utf8, get_project_root, merge_jsons
-from common.memory import read_bytes, read_string, unpack_to_int
+from common.memory import MemWriter
 from common.translate import convert_into_eng
 from json import dumps
 from openpyxl import load_workbook
@@ -12,14 +12,16 @@ import sys
 class GetPlayer:
 
     def __init__(self, address, debug=False):
+        self.proc = MemWriter()
+
         if debug:
             self.address = address
         else:
-            self.address = unpack_to_int(address)
+            self.address = self.proc.unpack_to_int(address)
 
-        self.ja_player_name = read_string(self.address + 24)
+        self.ja_player_name = self.proc.read_string(self.address + 24)
         self.en_player_name = self.__get_en_player_name(player_name=self.ja_player_name)
-        self.ja_sibling_name = read_string(self.address + 96)
+        self.ja_sibling_name = self.proc.read_string(self.address + 96)
         self.en_sibling_name = self.__get_en_player_name(player_name=self.ja_sibling_name)
         self.sibling_relationship = self.__determine_sibling_relationship()
 
@@ -28,7 +30,7 @@ class GetPlayer:
 
 
     def __determine_sibling_relationship(self):
-        check_byte = read_bytes(self.address + 96 + 19, size=1)
+        check_byte = self.proc.read_bytes(self.address + 96 + 19, size=1)
         if check_byte == b"\x01":
             return "older_brother"
         if check_byte == b"\x02":

--- a/app/hooking/quest.py
+++ b/app/hooking/quest.py
@@ -1,6 +1,6 @@
 from common.db_ops import sql_read, sql_write
 from common.lib import encode_to_utf8, get_project_root
-from common.memory import read_string, unpack_to_int, write_string
+from common.memory import MemWriter
 from common.translate import clean_up_and_return_items, detect_lang, Translate
 from json import dumps, loads
 
@@ -14,10 +14,12 @@ class Quest:
     quests = None
 
     def __init__(self, address, debug=False):
+        self.proc = MemWriter()
+
         if debug:
             self.address = address
         else:
-            self.address = unpack_to_int(address)
+            self.address = self.proc.unpack_to_int(address)
 
         self.subquest_name_address = self.address + 20
         self.quest_name_address = self.address + 76
@@ -25,11 +27,11 @@ class Quest:
         self.quest_rewards_address = self.address + 640
         self.quest_repeat_rewards_address = self.address + 744
 
-        self.subquest_name = read_string(self.subquest_name_address)
-        self.quest_name = read_string(self.quest_name_address)
-        self.quest_desc = read_string(self.quest_desc_address)
-        self.quest_rewards = read_string(self.quest_rewards_address)
-        self.quest_repeat_rewards = read_string(self.quest_repeat_rewards_address)
+        self.subquest_name = self.proc.read_string(self.subquest_name_address)
+        self.quest_name = self.proc.read_string(self.quest_name_address)
+        self.quest_desc = self.proc.read_string(self.quest_desc_address)
+        self.quest_rewards = self.proc.read_string(self.quest_rewards_address)
+        self.quest_repeat_rewards = self.proc.read_string(self.quest_repeat_rewards_address)
 
         self.is_ja = self.__is_ja()
 
@@ -46,31 +48,31 @@ class Quest:
     def __write_subquest_name(self):
         if self.is_ja:
             if data := self.__query_quest(self.subquest_name):
-                write_string(address=self.subquest_name_address, text=data)
+                self.proc.write_string(address=self.subquest_name_address, text=data)
 
 
     def __write_quest_name(self):
         if self.is_ja:
             if data := self.__query_quest(self.quest_name):
-                write_string(address=self.quest_name_address, text=data)
+                self.proc.write_string(address=self.quest_name_address, text=data)
 
 
     def __write_quest_desc(self):
         if self.is_ja:
             if data := self.__translate_quest_desc():
-                write_string(address=self.quest_desc_address, text=data)
+                self.proc.write_string(address=self.quest_desc_address, text=data)
 
 
     def __write_quest_rewards(self):
         if self.is_ja:
             if data := clean_up_and_return_items(self.quest_rewards):
-                write_string(address=self.quest_rewards_address, text=data)
+                self.proc.write_string(address=self.quest_rewards_address, text=data)
 
 
     def __write_repeat_quest_rewards(self):
         if self.is_ja:
             if data := clean_up_and_return_items(self.quest_repeat_rewards):
-                write_string(address=self.quest_repeat_rewards_address, text=data)
+                self.proc.write_string(address=self.quest_repeat_rewards_address, text=data)
 
 
     def __translate_quest_desc(self):

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from common.db_ops import ensure_db_structure
-from common.lib import get_project_root, setup_logging, wait_for_dqx_to_launch
+from common.lib import get_project_root, setup_logging
+from common.process import wait_for_dqx_to_launch
 from common.translate import determine_translation_service
 from common.update import (
     check_for_updates,

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+from clarity import loop_scan_for_walkthrough, run_scans
 from common.db_ops import ensure_db_structure
 from common.lib import get_project_root, setup_logging
 from common.process import wait_for_dqx_to_launch
@@ -8,6 +9,7 @@ from common.update import (
     download_dat_files,
 )
 from dqxcrypt.dqxcrypt import start_logger
+from hooking.hook import activate_hooks
 from multiprocessing import Process
 from pathlib import Path
 
@@ -62,11 +64,6 @@ def blast_off(
 
     try:
         wait_for_dqx_to_launch()
-
-        # Imports are done here as the program requires the game to be open otherwise.
-        # This allows us to test config and translate settings without launching everything.
-        from clarity import loop_scan_for_walkthrough, run_scans
-        from hooking.hook import activate_hooks
 
         def start_process(name: str, target, args: tuple):
             p = Process(name=name, target=target, args=args)


### PR DESCRIPTION
dqxclarity has always had an issue where you couldn't import or run a majority of the program if DQXGame.exe wasn't open. This was because pymem was being called and used globally across the file on import of `common.memory`. These changes instead will instantiate a new pymem instance on init of the class, which means you no longer need dqx open to import different modules. This can help with writing tests and general usability during debugging.