### PR TITLE
fix: Stuttering when calling hooks

### DIFF
--- a/app/hooking/dialog.py
+++ b/app/hooking/dialog.py
@@ -12,24 +12,26 @@ class Dialog:
 
     translator = Translate()
     region = translator.region_code
+    writer = None
 
     def __init__(self, address, debug=False):
-        writer = MemWriter()
+        if not Dialog.writer:
+            Dialog.writer = MemWriter()
         if debug:
             self.address = address
         else:
-            self.address = writer.unpack_to_int(address)
+            self.address = Dialog.writer.unpack_to_int(address)
 
-        self.text = writer.read_string(self.address)
+        self.text = Dialog.writer.read_string(self.address)
         if detect_lang(self.text):
             db_result = self.__read_db(self.text)
             if db_result:
-                writer.write_string(self.address, text=db_result)
+                Dialog.writer.write_string(self.address, text=db_result)
             else:
                 translated_text = self.__translate(self.text)
                 if translated_text:
                     self.__write_db(source_text=self.text, translated_text=translated_text)
-                    writer.write_string(self.address, text=translated_text)
+                    Dialog.writer.write_string(self.address, text=translated_text)
 
 
     def __read_db(self, text: str):

--- a/app/hooking/player.py
+++ b/app/hooking/player.py
@@ -11,17 +11,20 @@ import sys
 
 class GetPlayer:
 
+    writer = None
+
     def __init__(self, address, debug=False):
-        self.proc = MemWriter()
+        if not GetPlayer.writer:
+            GetPlayer.writer = MemWriter()
 
         if debug:
             self.address = address
         else:
-            self.address = self.proc.unpack_to_int(address)
+            self.address = GetPlayer.writer.unpack_to_int(address)
 
-        self.ja_player_name = self.proc.read_string(self.address + 24)
+        self.ja_player_name = GetPlayer.writer.read_string(self.address + 24)
         self.en_player_name = self.__get_en_player_name(player_name=self.ja_player_name)
-        self.ja_sibling_name = self.proc.read_string(self.address + 96)
+        self.ja_sibling_name = GetPlayer.writer.read_string(self.address + 96)
         self.en_sibling_name = self.__get_en_player_name(player_name=self.ja_sibling_name)
         self.sibling_relationship = self.__determine_sibling_relationship()
 
@@ -30,7 +33,7 @@ class GetPlayer:
 
 
     def __determine_sibling_relationship(self):
-        check_byte = self.proc.read_bytes(self.address + 96 + 19, size=1)
+        check_byte = GetPlayer.writer.read_bytes(self.address + 96 + 19, size=1)
         if check_byte == b"\x01":
             return "older_brother"
         if check_byte == b"\x02":

--- a/app/hooking/quest.py
+++ b/app/hooking/quest.py
@@ -12,14 +12,16 @@ class Quest:
 
     misc_files = get_project_root("misc_files")
     quests = None
+    writer = None
 
     def __init__(self, address, debug=False):
-        self.proc = MemWriter()
+        if not Quest.writer:
+            Quest.writer = MemWriter()
 
         if debug:
             self.address = address
         else:
-            self.address = self.proc.unpack_to_int(address)
+            self.address = Quest.writer.unpack_to_int(address)
 
         self.subquest_name_address = self.address + 20
         self.quest_name_address = self.address + 76
@@ -27,11 +29,11 @@ class Quest:
         self.quest_rewards_address = self.address + 640
         self.quest_repeat_rewards_address = self.address + 744
 
-        self.subquest_name = self.proc.read_string(self.subquest_name_address)
-        self.quest_name = self.proc.read_string(self.quest_name_address)
-        self.quest_desc = self.proc.read_string(self.quest_desc_address)
-        self.quest_rewards = self.proc.read_string(self.quest_rewards_address)
-        self.quest_repeat_rewards = self.proc.read_string(self.quest_repeat_rewards_address)
+        self.subquest_name = Quest.writer.read_string(self.subquest_name_address)
+        self.quest_name = Quest.writer.read_string(self.quest_name_address)
+        self.quest_desc = Quest.writer.read_string(self.quest_desc_address)
+        self.quest_rewards = Quest.writer.read_string(self.quest_rewards_address)
+        self.quest_repeat_rewards = Quest.writer.read_string(self.quest_repeat_rewards_address)
 
         self.is_ja = self.__is_ja()
 
@@ -48,31 +50,31 @@ class Quest:
     def __write_subquest_name(self):
         if self.is_ja:
             if data := self.__query_quest(self.subquest_name):
-                self.proc.write_string(address=self.subquest_name_address, text=data)
+                Quest.writer.write_string(address=self.subquest_name_address, text=data)
 
 
     def __write_quest_name(self):
         if self.is_ja:
             if data := self.__query_quest(self.quest_name):
-                self.proc.write_string(address=self.quest_name_address, text=data)
+                Quest.writer.write_string(address=self.quest_name_address, text=data)
 
 
     def __write_quest_desc(self):
         if self.is_ja:
             if data := self.__translate_quest_desc():
-                self.proc.write_string(address=self.quest_desc_address, text=data)
+                Quest.writer.write_string(address=self.quest_desc_address, text=data)
 
 
     def __write_quest_rewards(self):
         if self.is_ja:
             if data := clean_up_and_return_items(self.quest_rewards):
-                self.proc.write_string(address=self.quest_rewards_address, text=data)
+                Quest.writer.write_string(address=self.quest_rewards_address, text=data)
 
 
     def __write_repeat_quest_rewards(self):
         if self.is_ja:
             if data := clean_up_and_return_items(self.quest_repeat_rewards):
-                self.proc.write_string(address=self.quest_repeat_rewards_address, text=data)
+                Quest.writer.write_string(address=self.quest_repeat_rewards_address, text=data)
 
 
     def __translate_quest_desc(self):


### PR DESCRIPTION
Only initialize MemWriter once and store it as a global var in the class. This fixes a bug where MemWriter was being called every time on init, causing massive slowdowns/stuttering.