### PR TITLE
fix: (?) WinApi 299 errors

### DIFF
--- a/app/common/memory.py
+++ b/app/common/memory.py
@@ -97,6 +97,7 @@ class MemWriter:
                 )
         except pymem.exception.WinAPIError as e:
             if e.error_code == 299:  # impartial read, just return none.
+                log.debug("WinAPI Error 299")
                 return None
             else:
                 from common.process import is_dqx_process_running

--- a/app/pymem/pattern.py
+++ b/app/pymem/pattern.py
@@ -49,7 +49,12 @@ def scan_pattern_page(handle, address, pattern, *, all_protections=True, use_reg
     if mbi.state != pymem.ressources.structure.MEMORY_STATE.MEM_COMMIT or mbi.protect not in allowed_protections:
         return next_region, None
 
-    page_bytes = pymem.memory.read_bytes(handle, address, mbi.RegionSize - (address - mbi.BaseAddress))
+    try:
+        page_bytes = pymem.memory.read_bytes(handle, address, mbi.RegionSize)
+    except pymem.exception.WinAPIError as e:
+        if e.error_code == 299: # hiding an issue where memory changes between query and read
+            return next_region, None
+        raise pymem.exception.MemoryReadError(address, mbi.RegionSize, e.error_code)
 
     if not return_multiple:
         found = None

--- a/app/pymem/pattern.py
+++ b/app/pymem/pattern.py
@@ -49,7 +49,7 @@ def scan_pattern_page(handle, address, pattern, *, all_protections=True, use_reg
     if mbi.state != pymem.ressources.structure.MEMORY_STATE.MEM_COMMIT or mbi.protect not in allowed_protections:
         return next_region, None
 
-    page_bytes = pymem.memory.read_bytes(handle, address, mbi.RegionSize)
+    page_bytes = pymem.memory.read_bytes(handle, address, mbi.RegionSize - (address - mbi.BaseAddress))
 
     if not return_multiple:
         found = None


### PR DESCRIPTION
`pymem` is sometimes throwing this error when you're just standing still. In this instance, 299's happen when scanning through memory pages. `VirtualQueryEx `scans the page, then `pymem` reads the live page into a buffer. Problem is that the time between `VirtualQueryEx` scanning the page and `pymem` reading it, the underlying page protection has changed (in this case, rarely to 'No Access'), which generates the 299. We'll catch 299's during this operation and move on to the next page as what we would have read has been invalidated anyways.

Exception seen when scanning:

```python
2023-10-18 19:56:16.637 | ERROR    | clarity:run_scans:299 - An exception occurred. `dqxclarity` will exit.
Traceback (most recent call last):

  File "<string>", line 1, in <module>
  File "C:\Program Files (x86)\Python311-32\Lib\multiprocessing\spawn.py", line 120, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               │     │   └ 356
               │     └ 3
               └ <function _main at 0x018EC398>
  File "C:\Program Files (x86)\Python311-32\Lib\multiprocessing\spawn.py", line 133, in _main
    return self._bootstrap(parent_sentinel)
           │    │          └ 356
           │    └ <function BaseProcess._bootstrap at 0x01817E38>
           └ <Process name='Flavortown scanner' parent=28616 started>
  File "C:\Program Files (x86)\Python311-32\Lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
    │    └ <function BaseProcess.run at 0x018178E8>
    └ <Process name='Flavortown scanner' parent=28616 started>
  File "C:\Program Files (x86)\Python311-32\Lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
    │    │        │    │        │    └ {}
    │    │        │    │        └ <Process name='Flavortown scanner' parent=28616 started>
    │    │        │    └ (True, True)
    │    │        └ <Process name='Flavortown scanner' parent=28616 started>
    │    └ <function run_scans at 0x04C22078>
    └ <Process name='Flavortown scanner' parent=28616 started>

> File "C:\Users\me\Documents\github\dqx-translation-project\dqxclarity\app\clarity.py", line 291, in run_scans
    scan_for_npc_names()
    └ <function scan_for_npc_names at 0x04C1FF28>

  File "C:\Users\me\Documents\github\dqx-translation-project\dqxclarity\app\clarity.py", line 135, in scan_for_npc_names
    if npc_list := writer.pattern_scan(pattern=npc_monster_pattern, return_multiple=True):
                   │      │                    └ b'\\xD4\\x86..\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00....\\x00.......\\x00\\x00\\x00\\x00.\\x00\\x00\\x0...
                   │      └ <function MemWriter.pattern_scan at 0x03821A78>
                   └ <common.memory.MemWriter object at 0x0BA9A3D0>

  File "C:\Users\me\Documents\github\dqx-translation-project\dqxclarity\app\common\memory.py", line 91, in pattern_scan
    return pattern_scan_all(
           └ <function pattern_scan_all at 0x038188E8>

  File "C:\Users\me\Documents\github\dqx-translation-project\dqxclarity\app\pymem\pattern.py", line 143, in pattern_scan_all
    next_region, page_found = scan_pattern_page(handle, next_region, pattern, all_protections=all_protections, use_regex=use_regex, return_multiple=return_multiple)
    │                         │                 │       │            │                        │                          │                        
  └ True
    │                         │                 │       │            │                        │                          └ False
    │                         │                 │       │            │                        └ False
    │                         │                 │       │            └ b'\\xD4\\x86..\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00....\\x00.......\\x00\\x00\\x00\\x00.\\x00\\x00\\x0...
    │                         │                 │       └ 1259405312
    │                         │                 └ 59604
    │                         └ <function scan_pattern_page at 0x03818258>
    └ 1259405312

  File "C:\Users\me\Documents\github\dqx-translation-project\dqxclarity\app\pymem\pattern.py", line 52, in scan_pattern_page
    page_bytes = pymem.memory.read_bytes(handle, address, mbi.RegionSize)
                 │     │      │          │       │        │   └ <Field type=c_ulong, ofs=12, size=4>
                 │     │      │          │       │        └ <pymem.ressources.structure.MEMORY_BASIC_INFORMATION32 object at 0x01A183F0>
                 │     │      │          │       └ 1259405312
                 │     │      │          └ 59604
                 │     │      └ <function read_bytes at 0x037ED708>
                 │     └ <module 'pymem.memory' from 'C:\\Users\\me\\Documents\\github\\dqx-translation-project\\dqxclarity\\app\\pymem\\memory.py'>
                 └ <module 'pymem' from 'C:\\Users\\me\\Documents\\github\\dqx-translation-project\\dqxclarity\\app\\pymem\\__init__.py'>       

  File "C:\Users\me\Documents\github\dqx-translation-project\dqxclarity\app\pymem\memory.py", line 97, in read_bytes
    return read_ctype(handle, address, (byte * ctypes.c_char)(), get_py_value=False).raw
           │          │       │         │      │      └ <class 'ctypes.c_char'>
           │          │       │         │      └ <module 'ctypes' from 'C:\\Program Files (x86)\\Python311-32\\Lib\\ctypes\\__init__.py'>
           │          │       │         └ 163840
           │          │       └ 1259405312
           │          └ 59604
           └ <function read_ctype at 0x037ED758>

  File "C:\Users\me\Documents\github\dqx-translation-project\dqxclarity\app\pymem\memory.py", line 148, in read_ctype
    raise pymem.exception.WinAPIError(error_code)
          │     │         │           └ 299
          │     │         └ <class 'pymem.exception.WinAPIError'>
          │     └ <module 'pymem.exception' from 'C:\\Users\\me\\Documents\\github\\dqx-translation-project\\dqxclarity\\app\\pymem\\exceptio...
          └ <module 'pymem' from 'C:\\Users\\me\\Documents\\github\\dqx-translation-project\\dqxclarity\\app\\pymem\\__init__.py'>

pymem.exception.WinAPIError: Windows api error, error_code: 299
```
```