### PR TITLE
fix: Set working directory

### DIFF
--- a/app/run_clarity.ps1
+++ b/app/run_clarity.ps1
@@ -1,5 +1,9 @@
 $ClarityFlags = "-pnvcl"
 
+# ensure we're in the appropriate working directory in case it's overwritten
+# by the user's profile.
+Set-Location (Split-Path $MyInvocation.MyCommand.Path)
+
 function LogWrite($string) {
    Write-Host $string -ForegroundColor "Yellow"
 }


### PR DESCRIPTION
Ensure we're setting the correct working directory before running anything below. This can be a problem if a user is overriding their working directory in a custom profile.