### PR TITLE
ci: fix uploading existing dat/idx during release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -113,9 +113,10 @@ jobs:
 
       - name: Download previous release's dat/idx files
         if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          curl -LO https://github.com/dqx-translation-project/dqxclarity/releases/download/${{ env.CURRENT_TAG }}/data00000000.win32.dat1
-          curl -LO https://github.com/dqx-translation-project/dqxclarity/releases/download/${{ env.CURRENT_TAG }}/data00000000.win32.idx
+        uses: robinraju/release-downloader@v1.10
+        with:
+          latest: true
+          fileName: "data00000000*"
 
       - name: Create prod release
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
fixes issue where the downloaded files were 0kb. just use a gha to do instead.