### PR TITLE
ci: cleanup workflows

### DIFF
--- a/.github/workflows/_compile_launcher.yml
+++ b/.github/workflows/_compile_launcher.yml
@@ -1,0 +1,37 @@
+---
+name: Compile launcher
+
+on:
+  workflow_call:
+
+jobs:
+  compile_launcher:
+    runs-on: windows-latest
+    steps:
+      - name: Fetch branch name from comment
+        if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
+        id: fetch-branch-name
+        uses: xt0rted/pull-request-comment-branch@v2
+
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.fetch-branch-name.outputs.head_ref || 'main' }}
+
+      - name: Compile launcher into exe
+        run: |
+          cd app\launcher;
+          Invoke-WebRequest "https://github.com/AutoHotkey/Ahk2Exe/releases/download/Ahk2Exe1.1.37.01c1/Ahk2Exe1.1.37.01c1.zip" -OutFile "$cwd\ahk2exe.zip";
+          Invoke-WebRequest "https://www.autohotkey.com/download/ahk-v2.zip" -OutFile "$cwd\ahk.zip";
+          Expand-Archive -Path "$cwd\ahk2exe.zip" -DestinationPath . -Force;
+          Expand-Archive -Path "$cwd\ahk.zip" -DestinationPath . -Force;
+          & .\Ahk2Exe.exe /in "dqxclarity.ahk" /base "AutoHotkey64.exe" /icon "img/rosie.ico";
+
+      - name: Upload exe artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dqxclarity.exe
+          path: app\launcher\dqxclarity.exe
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,81 +1,57 @@
 ---
-  name: "Build zip for PR"
+name: Build zip for PR
 
-  on:
-    issue_comment:
-      types: [created]
+on:
+  issue_comment:
+    types: [created]
 
-  jobs:
-    compile_launcher:
-      runs-on: windows-latest
-      if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
-      steps:
-        - name: Fetch Branch Name
-          id: fetch-branch-name
-          uses: xt0rted/pull-request-comment-branch@v2
-        - name: Checkout PR branch (${{ steps.fetch-branch-name.outputs.head_ref }})
-          uses: actions/checkout@v4
-          with:
-            ref: ${{ steps.fetch-branch-name.outputs.head_ref }}
-        - name: Compile Exe
-          run: |
-            cd app\launcher;
-            Invoke-WebRequest "https://github.com/AutoHotkey/Ahk2Exe/releases/download/Ahk2Exe1.1.37.01c1/Ahk2Exe1.1.37.01c1.zip" -OutFile "$cwd\ahk2exe.zip";
-            Invoke-WebRequest "https://www.autohotkey.com/download/ahk-v2.zip" -OutFile "$cwd\ahk.zip";
-            Expand-Archive -Path "$cwd\ahk2exe.zip" -DestinationPath . -Force;
-            Expand-Archive -Path "$cwd\ahk.zip" -DestinationPath . -Force;
-            & .\Ahk2Exe.exe /in "dqxclarity.ahk" /base "AutoHotkey64.exe" /icon "img/rosie.ico";
-        - name: Upload exe
-          uses: actions/upload-artifact@v4
-          with:
-            name: dqxclarity.exe
-            path: app\launcher\dqxclarity.exe
-            if-no-files-found: error
-            retention-days: 1
-            overwrite: true
+jobs:
+  compile_launcher:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
+    uses: ./.github/workflows/_compile_launcher.yml
 
-    build:
-      needs: compile_launcher
-      runs-on: ubuntu-latest
-      if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
-      steps:
-        - name: Fetch Branch Name
-          id: fetch-branch-name
-          uses: xt0rted/pull-request-comment-branch@v2
+  build:
+    needs: compile_launcher
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/build')
+    steps:
+      - name: Fetch Branch Name
+        id: fetch-branch-name
+        uses: xt0rted/pull-request-comment-branch@v2
 
-        - name: Checkout PR branch (${{ steps.fetch-branch-name.outputs.head_ref }})
-          uses: actions/checkout@v4
-          with:
-            ref: ${{ steps.fetch-branch-name.outputs.head_ref }}
+      - name: Checkout PR branch (${{ steps.fetch-branch-name.outputs.head_ref }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.fetch-branch-name.outputs.head_ref }}
 
-        - name: Download exe
-          uses: actions/download-artifact@v4
-          with:
-            name: dqxclarity.exe
+      - name: Download exe
+        uses: actions/download-artifact@v4
+        with:
+          name: dqxclarity.exe
 
-        - name: Create SHORT_SHA env
-          run: echo "SHORT_SHA=`echo ${{ steps.fetch-branch-name.outputs.head_sha }} | cut -c1-8`" >> $GITHUB_ENV
+      - name: Create SHORT_SHA env
+        run: echo "SHORT_SHA=`echo ${{ steps.fetch-branch-name.outputs.head_sha }} | cut -c1-8`" >> $GITHUB_ENV
 
-        - name: Build package
-          run: |
-            rsync -av --exclude="imgs/" --exclude="launcher/" app/* dqxclarity/;
-            cp version.update requirements.txt user_settings.ini dqxclarity.exe dqxclarity/;
-            cp clarity_dialog.db dqxclarity/misc_files;
+      - name: Build package
+        run: |
+          rsync -av --exclude="imgs/" --exclude="launcher/" app/* dqxclarity/;
+          cp version.update requirements.txt user_settings.ini dqxclarity.exe dqxclarity/;
+          cp clarity_dialog.db dqxclarity/misc_files;
 
-            zip -r dqxclarity-dev-${SHORT_SHA}.zip dqxclarity
+          zip -r dqxclarity-dev-${SHORT_SHA}.zip dqxclarity
 
-        - name: Upload zip as artifact
-          uses: actions/upload-artifact@v4
-          with:
-            name: dqxclarity-dev-${{ env.SHORT_SHA }}
-            path: dqxclarity-dev-${{ env.SHORT_SHA }}.zip
-            if-no-files-found: error
+      - name: Upload zip as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dqxclarity-dev-${{ env.SHORT_SHA }}
+          path: dqxclarity-dev-${{ env.SHORT_SHA }}.zip
+          if-no-files-found: error
 
-        - name: Post comment to PR
-          uses: mshick/add-pr-comment@v2
-          with:
-            message: |
-              Link to workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-              Click on the zip at the bottom of the workflow to download.
-            refresh-message-position: true
-            preformatted: false
+      - name: Post comment to PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            Link to workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Click on the zip at the bottom of the workflow to download.
+          refresh-message-position: true
+          preformatted: false

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,5 @@
 ---
-name: "build-release-zip"
+name: Build release zip
 
 on:
   push:
@@ -10,27 +10,7 @@ on:
 
 jobs:
   compile_launcher:
-    name: Compile launcher
-    runs-on: windows-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Compile Exe
-        run: |
-          cd app\launcher;
-          Invoke-WebRequest "https://github.com/AutoHotkey/Ahk2Exe/releases/download/Ahk2Exe1.1.37.01c1/Ahk2Exe1.1.37.01c1.zip" -OutFile "$cwd\ahk2exe.zip";
-          Invoke-WebRequest "https://www.autohotkey.com/download/ahk-v2.zip" -OutFile "$cwd\ahk.zip";
-          Expand-Archive -Path "$cwd\ahk2exe.zip" -DestinationPath . -Force;
-          Expand-Archive -Path "$cwd\ahk.zip" -DestinationPath . -Force;
-          & .\Ahk2Exe.exe /in "dqxclarity.ahk" /base "AutoHotkey64.exe" /icon "img/rosie.ico";
-      - name: Upload exe
-        uses: actions/upload-artifact@v4
-        with:
-          name: dqxclarity.exe
-          path: app\launcher\dqxclarity.exe
-          if-no-files-found: error
-          retention-days: 1
-          overwrite: true
+    uses: ./.github/workflows/_compile_launcher.yml
 
   build-release-zip:
     name: Build release zip
@@ -59,7 +39,7 @@ jobs:
 
       - name: Build package
         run: |
-          rsync -av --exclude="imgs/" app/* dqxclarity/;
+          rsync -av --exclude="imgs/" --exclude="launcher/" app/* dqxclarity/;
           cp version.update requirements.txt user_settings.ini dqxclarity.exe dqxclarity/;
           cp clarity_dialog.db dqxclarity/misc_files;
 
@@ -98,6 +78,8 @@ jobs:
           commit_message: 'Automated bump of version.update'
           file_pattern: 'version.update'
           branch: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.SVC_ACCT_PAT }}
 
       # probably a better way to do this. big no-no to move an existing tag,
       # but there's no malicious stuff going on here. we just want the tag
@@ -110,6 +92,8 @@ jobs:
           git checkout ${{ steps.auto-commit-action.outputs.commit_hash }}
           git tag -f $NEW_TAG
           git push --force origin $NEW_TAG
+        env:
+          GITHUB_TOKEN: ${{ secrets.SVC_ACCT_PAT }}
 
       - name: Download previous release's dat/idx files
         if: startsWith(github.ref, 'refs/tags/v')
@@ -131,4 +115,4 @@ jobs:
           tag_name: ${{ github.ref }}
           name: 'Release: ${{ env.NEW_TAG }}'  # github.ref does not trim refs/tags/ when used here
           generate_release_notes: true
-          fail_on_unmatched_files: false
+          fail_on_unmatched_files: true


### PR DESCRIPTION
- DRY out the `compile_launcher` workflow job
- fix: Exclude the launcher folder from the release zip
- feat: when pushing commits to main from ci, specify the service account's PAT so that we can bypass pull requests. this should also allow enabling PRs on the base branch now (no more accidental merges to main)