### PR TITLE
fix: Launcher changes when running run_clarity.ps1

### DIFF
--- a/app/launcher/dqxclarity.ahk
+++ b/app/launcher/dqxclarity.ahk
@@ -3,7 +3,7 @@
 #Include <json>
 #Include <image>
 
-/* read ini */
+; read ini
 ini := {}
 ini.enabledeepl := IniRead(".\user_settings.ini", "translation", "enabledeepltranslate", "False")
 ini.deeplkey := IniRead(".\user_settings.ini", "translation", "deepltranslatekey", "")
@@ -15,13 +15,13 @@ ini.npcnames := IniRead(".\user_settings.ini", "launcher", "npcnames", "False")
 ini.updategamefiles := IniRead(".\user_settings.ini", "launcher", "updategamefiles", "False")
 ini.disableupdates := IniRead(".\user_settings.ini", "launcher", "disableupdates", "False")
 
-/* main window */
+; main window
 Launcher := Gui()
 Launcher.Opt("-MaximizeBox")
 
 Launcher.AddPicture("YP+1 w150 h-1 vImage", LoadImageFromResource("img/rosie.png"))
 
-/* configuration group */
+; configuration group
 Launcher.AddGroupBox("ys+10 w200 h120 c0B817C", "Configuration")
 Launcher.AddCheckBox("XP+10 YP+20 vCommunityLogging Checked" . ConvertBoolToState(ini.communitylogging), "Community Logging")
 Launcher.AddCheckBox("vPlayerNames Checked" . ConvertBoolToState(ini.playernames), "Player Names")
@@ -30,7 +30,7 @@ Launcher.AddCheckBox("vUpdateGameFiles Checked" . ConvertBoolToState(ini.updateg
 Launcher.AddCheckBox("vDisableUpdates Checked"  . ConvertBoolToState(ini.disableupdates), "Disable Updates")
 Launcher.AddStatusBar("vStatusBar", "")
 
-/* api group */
+; api group
 Launcher.AddGroupBox("Section YP+30 XP-10 w200 h150 c0B817C", "API Settings")
 Launcher.AddCheckBox("XP+10 YP+20 vUseDeepL Checked" . ConvertBoolToState(ini.enabledeepl), "Use DeepL")
 Launcher.AddEdit("YP+20 W180 r1 vDeepLKey", ini.deeplkey).Opt("+Password")
@@ -38,11 +38,11 @@ Launcher.AddCheckBox("XP vUseGoogleTranslate Checked" . ConvertBoolToState(ini.e
 Launcher.AddEdit("YP+20 W180 r1 vGoogleTranslateKey", ini.googletranslatekey).Opt("+Password")
 Launcher.AddButton("YP+30 w180 vValidateKey", "Validate Enabled Key").OnEvent("Click", ValidateKey)
 
-/* launch */
+; launch
 Launcher.AddButton("YP+60 XS+10 w80 h30 vRunProgram", "Run").Opt("+Default")
 Launcher.AddButton("x+20 vGitHub w80 h30", "GitHub").OnEvent("Click", OpenGitHub)
 
-/* tooltips */
+; tooltips
 Launcher["CommunityLogging"].ToolTip := "Enables logging of internal game files to a text file."
 Launcher["PlayerNames"].ToolTip := "Transliterates Japanese player names to English."
 Launcher["NPCNames"].ToolTip := "Translate Japanese NPC names to English."
@@ -56,21 +56,19 @@ Launcher["ValidateKey"].ToolTip := "Validate that the selected API key works. Ch
 Launcher["Run"].ToolTip := "Run the program."
 Launcher["GitHub"].ToolTip := "View the source code in your default browser."
 
-/* function handlers */
+; function handlers
 Launcher["CommunityLogging"].OnEvent("Click", CommunityLoggingWarning)
 Launcher["UseDeepL"].OnEvent("Click", CheckedDeepL)
 Launcher["UseGoogleTranslate"].OnEvent("Click", CheckedGoogleTranslate)
 Launcher["RunProgram"].OnEvent("Click", RunProgram)
 
-/* show launcher */
+; show launcher
 Launcher.Show("AutoSize Center")
 OnMessage(0x0200, On_WM_MOUSEMOVE)
 
 
 CheckedDeepL(*) {
-    /*
-    Behavior when the "Use DeepL" checkbox is checked.
-    */
+    ; Behavior when the "Use DeepL" checkbox is checked.
     Launcher["UseGoogleTranslate"].value := 0
     Launcher["GoogleTranslateKey"].Opt("+Disabled")
     Launcher["DeepLKey"].Opt("-Disabled")
@@ -78,9 +76,7 @@ CheckedDeepL(*) {
 
 
 CheckedGoogleTranslate(*) {
-    /*
-    Behavior when the "Use Google Translate" checkbox is checked.
-    */
+    ; Behavior when the "Use Google Translate" checkbox is checked.
     Launcher["UseDeepL"].value := 0
     Launcher["DeepLKey"].Opt("+Disabled")
     Launcher["GoogleTranslateKey"].Opt("-Disabled")
@@ -88,10 +84,8 @@ CheckedGoogleTranslate(*) {
 
 
 ValidateKey(*) {
-    /*
-    Validates the enabled API key by reaching out to whichever
-    API service is checked.
-    */
+    ; Validates the enabled API key by reaching out to whichever
+    ; API service is checked.
     if (Launcher["UseDeepL"].value = 1) {
         DeepLKey := Launcher["DeepLKey"].value
         if (DeepLKey) {
@@ -140,19 +134,14 @@ ValidateKey(*) {
 
 
 UpdateStatusBar(text) {
-    /*
-    Updates the status bar at the bottom of the GUI.
-
-    @param text Text to update the status bar.
-    */
+    ; Updates the status bar at the bottom of the GUI.
+    ;; @param text Text to update the status bar.
     Launcher["StatusBar"].SetText(text)
 }
 
 
 CommunityLoggingWarning(*) {
-    /*
-    Send a warning if community logging is enabled as it can be buggy.
-    */
+    ; Send a warning if community logging is enabled as it can be buggy.
     if Launcher["CommunityLogging"].value = 1 {
         Result := MsgBox("You have enabled community logging.`n`nThis feature is unstable and may result in unexpected behavior while playing, up to and including crashes. Do not report issues of crashing if you have this enabled.`n`nIf you still want to enable this to help with the project, click `"Yes.`" Otherwise, click `"No.`"", "Community Logging", "YN Icon! Default2 0x1000")
         if (Result = "No") {
@@ -163,19 +152,14 @@ CommunityLoggingWarning(*) {
 
 
 OpenGitHub(*) {
-    /*
-    Opens the dqxclarity repository in the user's browser.
-    */
+    ; Opens the dqxclarity repository in the user's browser.
     Run("https://github.com/dqx-translation-project/dqxclarity")
 }
 
 
 ConvertBoolToState(value) {
-    /*
-    Used for interpreting the values of the user_settings.ini file.
-
-    @param value Value to convert to a state.
-    */
+    ; Used for interpreting the values of the user_settings.ini file.
+    ;; @param value Value to convert to a state.
     if (value = "True")
         return 1
     else
@@ -184,11 +168,8 @@ ConvertBoolToState(value) {
 
 
 ConvertStateToBool(value) {
-    /*
-    Used for interpreting the values of the user_settings.ini file.
-
-    @param value Value to convert to a bool.
-    */
+    ; Used for interpreting the values of the user_settings.ini file.
+    ;; @param value Value to convert to a bool.
     if (value = "1")
         return "True"
     else
@@ -197,11 +178,9 @@ ConvertStateToBool(value) {
 
 
 On_WM_MOUSEMOVE(wParam, lParam, msg, Hwnd) {
-    /*
-    Updates the status bar at the bottom of the GUI
-    based on what control the user has their mouse
-    hovered over.
-    */
+    ; Updates the status bar at the bottom of the GUI
+    ; based on what control the user has their mouse
+    ; hovered over.
     static PrevHwnd := 0
     if (Hwnd != PrevHwnd)
     {
@@ -218,19 +197,15 @@ On_WM_MOUSEMOVE(wParam, lParam, msg, Hwnd) {
 
 
 FakeFileInstall(*) {
-    /*
-    This is necessary to exist during compile. This tells Ahk2exe to
-    include the file during compilation, but since we never call the
-    function, it won't extract the image
-    */
+    ; This is necessary to exist during compile. This tells Ahk2exe to
+    ; include the file during compilation, but since we never call the
+    ; function, it won't extract the image
     FileInstall("img/rosie.png", "*")
 }
 
 
 SaveToIni(*) {
-    /*
-    Saves all of the user settings to user_settings.ini.
-    */
+    ; Saves all of the user settings to user_settings.ini.
     IniWrite(ConvertStateToBool(Launcher["CommunityLogging"].value), ".\user_settings.ini", "launcher", "communitylogging")
     IniWrite(ConvertStateToBool(Launcher["PlayerNames"].value), ".\user_settings.ini", "launcher", "playernames")
     IniWrite(ConvertStateToBool(Launcher["NPCNames"].value), ".\user_settings.ini", "launcher", "npcnames")
@@ -244,10 +219,8 @@ SaveToIni(*) {
 
 
 GetClarityArgs(*) {
-    /*
-    Read the GUI to see which arguments we need to pass to dqxclarity.
-    Returns the appropriate arguments.
-    */
+    ; Read the GUI to see which arguments we need to pass to dqxclarity.
+    ; Returns the appropriate arguments.
     args := ""
     if (Launcher["CommunityLogging"].value = 1)
         args := args . "l"
@@ -271,8 +244,12 @@ GetClarityArgs(*) {
 
 RunProgram(*) {
     SaveToIni
-    if (FileExist("run_clarity.ps1"))
-        Run("cmd.exe /c powershell.exe -ExecutionPolicy Unrestricted -File run_clarity.ps1 " . GetClarityArgs())
+    if (FileExist("run_clarity.ps1")) {
+        ; When users download clarity, Windows tends to mark the ps1 script as unsafe, which can trigger
+        ; a security warning when launching run_clarity.ps1.
+        Run("powershell.exe Unblock-File -Path .\run_clarity.ps1")
+        Run("cmd.exe /c powershell.exe -ExecutionPolicy Bypass -File run_clarity.ps1 " . GetClarityArgs())
+    }
     else
         MsgBox("Did not find run_clarity.ps1 in this directory.`n`nEnsure you didn't move dqxclarity.exe outside of the directory.",, "OK Iconx 0x1000")
     ExitApp


### PR DESCRIPTION
- Update launcher to just Bypass.
- Uses Unblock-File prior to execution to ensure user doesn't receive a security warning when running.
- Replaces comment format with semicolons to get GitHub to render the code properly in the UI.