### PR TITLE
feat: Add ability to scan only for data pages

### DIFF
--- a/app/common/memory.py
+++ b/app/common/memory.py
@@ -74,7 +74,7 @@ class MemWriter:
         return self.proc.write_string(address, text + "\x00")
 
 
-    def pattern_scan(self, pattern: bytes, return_multiple=False, use_regex=False, module=None, all_protections: bool = False):
+    def pattern_scan(self, pattern: bytes, return_multiple=False, use_regex=False, module=None, all_protections: bool=False, data_only: bool=False):
         """Scan for a byte pattern."""
         if module is not None:
             return self.proc.pattern_scan_module(
@@ -87,7 +87,8 @@ class MemWriter:
                 pattern=pattern,
                 all_protections=all_protections,
                 return_multiple=return_multiple,
-                use_regex=use_regex
+                use_regex=use_regex,
+                data_only=data_only
             )
 
     def get_ptr_address(self, base: int, offsets: list):

--- a/app/common/process.py
+++ b/app/common/process.py
@@ -43,6 +43,6 @@ def wait_for_dqx_to_launch() -> bool:
     log.success("DQXGame.exe found. Make sure you're on the \"Important notice\" screen.")
     writer = MemWriter()
     while True:
-        if writer.pattern_scan(pattern=notice_string):
+        if writer.pattern_scan(pattern=notice_string, data_only=True):
             log.success("\"Important notice\" screen found.")
             return

--- a/app/pymem/__init__.py
+++ b/app/pymem/__init__.py
@@ -339,7 +339,7 @@ class Pymem(object):
             raise pymem.exception.ProcessError('You must open a process before calling this method')
         return pymem.memory.free_memory(self.process_handle, address)
 
-    def pattern_scan_all(self, pattern, *, return_multiple=False, all_protections: bool = False, use_regex: bool = False):
+    def pattern_scan_all(self, pattern, *, return_multiple=False, all_protections: bool = False, use_regex: bool = False, data_only: bool = False):
         """Scan the entire address space of this process for a regex pattern
 
         Parameters
@@ -360,7 +360,8 @@ class Pymem(object):
             pattern,
             return_multiple=return_multiple,
             all_protections=all_protections,
-            use_regex=use_regex
+            use_regex=use_regex,
+            data_only=data_only
         )
 
     def pattern_scan_module(self, pattern, module, *, return_multiple=False):


### PR DESCRIPTION
pymem's `pattern_scan_all` currently scans the entirety of the process's memory region using `scan_pattern_page` to iterate over each memory page to evaluate if we want to read it in and run a query against it.

clarity generally only cares about memory that:

- is of type "PRIVATE" or "MAPPED" (we don't care about memory that is already mapped to an image, which exists in a module)
- has anything but PAGE_READWRITE defined in its protections (if we're scanning for data, the intent is to modify it)

this adds a `data_only` flag to `pattern_scan` so that we only scan for readable, writable memory. This offers a slight boost (on my pc) of about 200ms when running the main `run_scans` loop. This isn't significant, but as we may scan several hundreds of times over the course of a game session, this time adds up.