### PR TITLE
feat: Launcher changes

### DIFF
--- a/app/launcher/dqxclarity.ahk
+++ b/app/launcher/dqxclarity.ahk
@@ -248,7 +248,8 @@ RunProgram(*) {
         ; When users download clarity, Windows tends to mark the ps1 script as unsafe, which can trigger
         ; a security warning when launching run_clarity.ps1. Run this in the same Run() call so that a window
         ; doesn't flicker when it executes.
-        Run("cmd.exe /c powershell.exe Unblock-File -Path .\run_clarity.ps1; cmd.exe /c powershell.exe -ExecutionPolicy Bypass -File run_clarity.ps1 " . GetClarityArgs())
+        windows_root := EnvGet("SystemRoot")
+        Run(Format("{1}\System32\cmd.exe /c {1}\System32\WindowsPowerShell\v1.0\powershell.exe Unblock-File -Path .\run_clarity.ps1; {1}\System32\cmd.exe /c {1}\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File run_clarity.ps1 {2}", windows_root, GetClarityArgs()))
     }
     else
         MsgBox("Did not find run_clarity.ps1 in this directory.`n`nEnsure you didn't move dqxclarity.exe outside of the directory.",, "OK Iconx 0x1000")

--- a/app/launcher/dqxclarity.ahk
+++ b/app/launcher/dqxclarity.ahk
@@ -242,7 +242,20 @@ GetClarityArgs(*) {
     return args
 }
 
+
+CheckScriptPath(*) {
+    ; Ensure the user doesn't run dqxclarity from Program Files, as this is known
+    ; to cause issues saving user settings and writing to the clarity db.
+    program_files := EnvGet("programfiles(x86)")
+    if InStr(A_ScriptDir, program_files) {
+        MsgBox(Format("You placed this folder in {1}. This is known to cause issues with dqxclarity. Please move the directory somewhere else (Desktop, Documents, etc.)", program_files),, "OK Iconx 0x1000")
+        ExitApp
+    }
+}
+
+
 RunProgram(*) {
+    CheckScriptPath
     SaveToIni
     if (FileExist("run_clarity.ps1")) {
         ; When users download clarity, Windows tends to mark the ps1 script as unsafe, which can trigger

--- a/app/launcher/dqxclarity.ahk
+++ b/app/launcher/dqxclarity.ahk
@@ -262,7 +262,10 @@ RunProgram(*) {
         ; a security warning when launching run_clarity.ps1. Run this in the same Run() call so that a window
         ; doesn't flicker when it executes.
         windows_root := EnvGet("SystemRoot")
-        Run(Format("{1}\System32\cmd.exe /c {1}\System32\WindowsPowerShell\v1.0\powershell.exe Unblock-File -Path .\run_clarity.ps1; {1}\System32\cmd.exe /c {1}\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File run_clarity.ps1 {2}", windows_root, GetClarityArgs()))
+        cmd_path := Format("{1}\System32\cmd.exe", windows_root)
+        powershell_path := Format("{1}\System32\WindowsPowerShell\v1.0\powershell.exe", windows_root)
+
+        Run(Format("{1} /c {2} Unblock-File -Path .\run_clarity.ps1; {1} /c {2} -ExecutionPolicy Bypass -File run_clarity.ps1 {3}", cmd_path, powershell_path, GetClarityArgs()))
     }
     else
         MsgBox("Did not find run_clarity.ps1 in this directory.`n`nEnsure you didn't move dqxclarity.exe outside of the directory.",, "OK Iconx 0x1000")

--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,6 @@ import time
 
 # fmt: off
 @click.command()
-@click.option('-v', '--debug', is_flag=True, help="Turns on additional logging to console. This will be removed in a future update.")
 @click.option('-u', '--disable-update-check', is_flag=True, help="Disables checking for updates on each launch.")
 @click.option('-c', '--communication-window', is_flag=True,help="Writes hooks into the game to translate the dialog window with a live translation service.")
 @click.option('-p', '--player-names', is_flag=True,help="Scans for player names and changes them to their Romaji counterpart.")
@@ -42,7 +41,6 @@ def blast_off(
     npc_names=False,
     community_logging=False,
     update_dat=False,
-    debug=False  # this will be removed in a future update.
 ):
 
     # configure logging


### PR DESCRIPTION
* Instead of expecting the user to have `powershell.exe` and `cmd.exe` in their PATH, use the fully qualified path to the executables instead.
* If the user installs in `C:\Program Files (x86)` (i.e: they tried to install it by the game or something), show an error telling the user to move it and exit. We can't typically save user settings or db changes when clarity is in this directory because of windows permissions.