### PR TITLE
feat: add PAGE_EXECUTE_WRITECOPY to allowed protections

### DIFF
--- a/app/pymem/pattern.py
+++ b/app/pymem/pattern.py
@@ -44,12 +44,14 @@ def scan_pattern_page(handle, address, pattern, *, all_protections=True, use_reg
         allowed_protections = [
             pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_READ,
             pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_READWRITE,
+            pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_WRITECOPY,  # steamos opens wine processes with this
             pymem.ressources.structure.MEMORY_PROTECTION.PAGE_READWRITE,
             pymem.ressources.structure.MEMORY_PROTECTION.PAGE_READONLY,
         ]
     else:
         allowed_protections = [
-            pymem.ressources.structure.MEMORY_PROTECTION.PAGE_READWRITE
+            pymem.ressources.structure.MEMORY_PROTECTION.PAGE_READWRITE,
+            pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_WRITECOPY,  # steamos opens wine processes with this
         ]
 
     if mbi.state != pymem.ressources.structure.MEMORY_STATE.MEM_COMMIT or mbi.protect not in allowed_protections:


### PR DESCRIPTION
When DQX is launched in SteamOS via wine, this protection is applied instead of what we'd usually see on Windows. This is necessary in order for us to scan for patterns within modules that have these protections.