### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click==8.1.7
 configparser==7.1.0
 deepl==1.20.0
-frida==16.5.6
+frida==16.4.5
 google-api-python-client==2.154.0
 langdetect==1.0.9
 loguru==0.7.2


### PR DESCRIPTION
Changes frida to use an older version (16.4.5) which still works when using community logging. This is what dqx_dat_dump uses at present and this still works as well.