### PR TITLE
freeze fix

### DIFF
--- a/app/hooking/dialog.py
+++ b/app/hooking/dialog.py
@@ -22,6 +22,9 @@ class Dialog:
             self.text_address = Dialog.writer.unpack_to_int(text_address)
             self.npc_address = Dialog.writer.unpack_to_int(npc_address)
 
+        # npc name is on the stack, not directly in a register.
+        self.npc_address = Dialog.writer.proc.read_long(self.npc_address + 0x14)
+
         self.text = Dialog.writer.read_string(self.text_address)
         self.npc_name = self.__get_npc_name()
 
@@ -43,9 +46,8 @@ class Dialog:
 
 
     def __get_npc_name(self):
-        esp_addr = Dialog.writer.unpack_to_int(self.npc_address + 8) # esp+8
         try:
-            npc_name = Dialog.writer.read_string(esp_addr)
+            npc_name = Dialog.writer.read_string(self.npc_address)
             if not npc_name:
                 npc_name = "No_NPC"
         except:

--- a/app/hooking/network_text.py
+++ b/app/hooking/network_text.py
@@ -145,6 +145,18 @@ class NetworkTextTranslate:
                     name_to_write = NetworkTextTranslate.m00_text[text]
                 else:
                     name_to_write = transliterate_player_name(text)
+
+                # the original strength length (in bytes) must be the exact same size as what we write, or the string will break.
+                orig_len = len(text.encode('utf-8'))
+                new_len = len(name_to_write.encode('utf-8'))
+
+                if new_len > orig_len:
+                    name_to_write = name_to_write[:orig_len]
+                elif new_len < orig_len:
+                    # we need to pad the string with spaces until it's the same length as orig_len.
+                    while len(name_to_write.encode('utf-8')) <= orig_len:
+                        name_to_write += " "
+
                 NetworkTextTranslate.writer.write_string(self.text_address, name_to_write)
 
             # generic string


### PR DESCRIPTION
fixes:

- random encounters where the game won't move dialogue forward or the dialogue behavior is incorrect
- dialogue hanging for 10-15 seconds to translate