### PR TITLE
fix: Don't write translation failures to the db.

### DIFF
--- a/app/common/measure.py
+++ b/app/common/measure.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from loguru import logger
+from loguru import logger as log
 
 import inspect
 import time
@@ -16,6 +16,6 @@ def measure_duration(func):
         start = time.time()
         result = func(*args, **kwargs)
         duration = time.time() - start
-        logger.debug(f"[{module}.{name}:{line}] Execution took {duration:.6f} seconds")
+        log.debug(f"[{module}.{name}:{line}] Execution took {duration:.6f} seconds")
         return result
     return wrapper

--- a/app/common/translate.py
+++ b/app/common/translate.py
@@ -3,6 +3,7 @@ from common.db_ops import generate_glossary_dict, generate_m00_dict, init_db
 from common.translators.deepl import DeepLTranslate
 from common.translators.googletranslate import GoogleTranslate
 from common.translators.googletranslatefree import GoogleTranslateFree
+from loguru import logger as log
 
 import langdetect
 import pykakasi
@@ -217,7 +218,7 @@ class Translator():
             translator = GoogleTranslateFree()
             return translator.translate(text)
         else:
-            raise ValueError("Invalid translation service specified in user config.")
+            log.exception("Invalid translation service specified in user config.")
 
 
     def translate(self, text: str, wrap_width: int, max_lines=None, add_brs=True):
@@ -356,6 +357,9 @@ class Translator():
             count += 1
 
         translated_list = self.__api_translate(text=to_translate)
+        if not translated_list or len(translated_list) != len(to_translate):
+            log.exception(f"{self.service} translation failed.")
+            return ""
 
         # update our str_attrs dict with the new, translated string
         count = 0

--- a/app/common/translators/googletranslate.py
+++ b/app/common/translators/googletranslate.py
@@ -1,6 +1,6 @@
 from common.measure import measure_duration
 from googleapiclient.discovery import build
-from loguru import logger
+from loguru import logger as log
 
 
 # uses Google's official Translate API to send translations.
@@ -22,5 +22,5 @@ class GoogleTranslate:
 
             return results
         except Exception as e:
-            logger.error(f"Error during request: {e}")
+            log.error(f"Error during request: {e}")
             return []

--- a/app/common/translators/googletranslatefree.py
+++ b/app/common/translators/googletranslatefree.py
@@ -1,5 +1,5 @@
 from common.measure import measure_duration
-from loguru import logger
+from loguru import logger as log
 
 import html
 import re
@@ -40,5 +40,5 @@ class GoogleTranslateFree:
                 results.append(self.__parse_response(response.text))
             return results
         except Exception as e:
-            logger.error(f"Error during request: {e}")
+            log.error(f"Error during request: {e}")
             return []


### PR DESCRIPTION
- When a translation reaches out and times out or fails, don't continue processing the string as it just returns just the glossary words instead
- Add consistent logging calls (use `log` as the logging call)
- Don't retry failed DeepL calls -- just fail once so that we aren't holding the thread up that the game runs on, making the player wait longer
- Reduce the timeout period when waiting for a response from DeepL so that we aren't hanging up the thread for long periods of time