### PR TITLE
revert: deepl model type

### DIFF
--- a/app/common/translators/deepl.py
+++ b/app/common/translators/deepl.py
@@ -24,7 +24,6 @@ class DeepLTranslate():
                 source_lang="ja",
                 target_lang="en-us",
                 preserve_formatting=True,
-                model_type="prefer_quality_optimized",
             )
 
             results = []


### PR DESCRIPTION
DeepL does not preserve newlines in their quality optimized model type.

With `model_type="prefer_quality_optimized"`:

```
"\nEast Area West Area Fashion Street In front of Fairy's Well In front of Megistris Castle"
```

Excluding `model_type`:

```
"\nEast Area\nWest Area\nFashion Street\nIn front of the fairy well\nIn front of Megistris Castle\n"
```

Without the newlines, this breaks select lists in game.