### PR TITLE
fix: pin google-api-core to 2.27.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 configparser==7.2.0
 deepl==1.22.0
 frida==16.4.5
+google-api-core==2.27.0
 google-api-python-client==2.183.0
 langdetect==1.0.9
 loguru==0.7.3


### PR DESCRIPTION
Someone at Google messed up and didn't include a new `packaging` dependency.

https://github.com/googleapis/python-api-core/commit/d36e896f98a2371c4d58ce1a7a3bc1a77a081836#diff-89e3dc79e0ad8b9d816f15f6683e95597a434c8c385eb4d1f391770fae13856dR28

This pins us to a previous version that doesn't require this.