### PR TITLE
Add configuration for translating nameplates only if user selected.

### DIFF
--- a/app/hooking/hook.py
+++ b/app/hooking/hook.py
@@ -264,7 +264,9 @@ def blowfish_logger_detour():
     return trampoline
 
 
-def activate_hooks(communication_window: bool, community_logging: bool) -> None:
+def activate_hooks(
+    communication_window: bool, nameplates: bool, community_logging: bool
+) -> None:
     """Activates all hooks.
 
     :param communication_window: True if user requested to translate
@@ -275,12 +277,16 @@ def activate_hooks(communication_window: bool, community_logging: bool) -> None:
     """
     # activates all hooks. add any new hooks to this list
     hooks = []
-    if hook := player_name_detour():
+    if hook := corner_text_detour():
         hooks.append(hook)
     if hook := network_text_detour():
         hooks.append(hook)
-    if hook := corner_text_detour():
+    if hook := player_name_detour():
         hooks.append(hook)
+
+    if nameplates:
+        if hook := nameplates_detour():
+            hooks.append(hook)
 
     if community_logging:
         if hook := hash_logger_detour():
@@ -296,8 +302,6 @@ def activate_hooks(communication_window: bool, community_logging: bool) -> None:
         if hook := quest_text_detour():
             hooks.append(hook)
         if hook := walkthrough_detour():
-            hooks.append(hook)
-        if hook := nameplates_detour():
             hooks.append(hook)
 
     if hooks:

--- a/app/launcher/dqxclarity.ahk
+++ b/app/launcher/dqxclarity.ahk
@@ -11,8 +11,7 @@ ini.enablegoogletranslate := IniRead(".\user_settings.ini", "translation", "enab
 ini.googletranslatekey := IniRead(".\user_settings.ini", "translation", "googletranslatekey", "")
 ini.enablegoogletranslatefree := IniRead(".\user_settings.ini", "translation", "enablegoogletranslatefree", "False")
 ini.communitylogging := IniRead(".\user_settings.ini", "launcher", "communitylogging", "False")
-ini.playernames := IniRead(".\user_settings.ini", "launcher", "playernames", "False")
-ini.npcnames := IniRead(".\user_settings.ini", "launcher", "npcnames", "False")
+ini.nameplates := IniRead(".\user_settings.ini", "launcher", "nameplates", "False")
 ini.updategamefiles := IniRead(".\user_settings.ini", "launcher", "updategamefiles", "False")
 ini.disableupdates := IniRead(".\user_settings.ini", "launcher", "disableupdates", "False")
 
@@ -25,8 +24,7 @@ Launcher.AddPicture("YP+1 w150 h-1 vImage", LoadImageFromResource("img/rosie.png
 ; configuration group
 Launcher.AddGroupBox("ys+10 w200 h120 c0B817C", "Configuration")
 Launcher.AddCheckBox("XP+10 YP+20 vCommunityLogging Checked" . ConvertBoolToState(ini.communitylogging), "Community Logging")
-Launcher.AddCheckBox("vPlayerNames Checked" . ConvertBoolToState(ini.playernames), "Player Names")
-Launcher.AddCheckBox("vNPCNames Checked" . ConvertBoolToState(ini.npcnames), "NPC Names")
+Launcher.AddCheckBox("vNameplates Checked" . ConvertBoolToState(ini.nameplates), "Nameplates")
 Launcher.AddCheckBox("vUpdateGameFiles Checked" . ConvertBoolToState(ini.updategamefiles), "Update Game Files")
 Launcher.AddCheckBox("vDisableUpdates Checked"  . ConvertBoolToState(ini.disableupdates), "Disable Updates")
 Launcher.AddStatusBar("vStatusBar", "")
@@ -46,8 +44,7 @@ Launcher.AddButton("x+20 vGitHub w80 h30", "GitHub").OnEvent("Click", OpenGitHub
 
 ; tooltips
 Launcher["CommunityLogging"].ToolTip := "Enables logging of internal game files to a text file."
-Launcher["PlayerNames"].ToolTip := "Transliterates Japanese player names to English."
-Launcher["NPCNames"].ToolTip := "Translate Japanese NPC names to English."
+Launcher["Nameplates"].ToolTip := "Transliterates Japanese nameplates to English."
 Launcher["UpdateGameFiles"].ToolTip := "Downloads/updates the modded DAT/IDX files."
 Launcher["DisableUpdates"].ToolTip := "Don't check for dqxclarity updates on launch."
 Launcher["UseDeepL"].ToolTip := "Enable DeepL as your choice of external translation."
@@ -210,8 +207,7 @@ FakeFileInstall(*) {
 SaveToIni(*) {
     ; Saves all of the user settings to user_settings.ini.
     IniWrite(ConvertStateToBool(Launcher["CommunityLogging"].value), ".\user_settings.ini", "launcher", "communitylogging")
-    IniWrite(ConvertStateToBool(Launcher["PlayerNames"].value), ".\user_settings.ini", "launcher", "playernames")
-    IniWrite(ConvertStateToBool(Launcher["NPCNames"].value), ".\user_settings.ini", "launcher", "npcnames")
+    IniWrite(ConvertStateToBool(Launcher["Nameplates"].value), ".\user_settings.ini", "launcher", "nameplates")
     IniWrite(ConvertStateToBool(Launcher["UpdateGameFiles"].value), ".\user_settings.ini", "launcher", "updategamefiles")
     IniWrite(ConvertStateToBool(Launcher["DisableUpdates"].value), ".\user_settings.ini", "launcher", "disableupdates")
     IniWrite(ConvertStateToBool(Launcher["UseDeepL"].value), ".\user_settings.ini", "translation", "enabledeepltranslate")
@@ -228,10 +224,8 @@ GetClarityArgs(*) {
     args := ""
     if (Launcher["CommunityLogging"].value = 1)
         args := args . "--community-logging"
-    if (Launcher["PlayerNames"].value = 1)
-        args := args . " " . "--player-names"
-    if (Launcher["NPCNames"].value = 1)
-        args := args . " " . "--npc-names"
+    if (Launcher["Nameplates"].value = 1)
+        args := args . " " . "--nameplates"
     if (Launcher["UpdateGameFiles"].value = 1)
         args := args . " " . "--update-dat"
     if (Launcher["DisableUpdates"].value = 1)

--- a/app/main.py
+++ b/app/main.py
@@ -35,16 +35,10 @@ def parse_arguments():
         help="Writes hooks into the game to translate the dialog window with a live translation service.",
     )
     parser.add_argument(
-        "-p",
-        "--player-names",
-        action="store_true",
-        help="Scans for player names and changes them to their Romaji counterpart.",
-    )
-    parser.add_argument(
         "-n",
-        "--npc-names",
+        "--nameplates",
         action="store_true",
-        help="Scans for NPC names and changes them to their Romaji counterpart.",
+        help="Scans for nameplate names and transliterates them to their Romaji counterpart.",
     )
     parser.add_argument(
         "-l",
@@ -105,6 +99,7 @@ def main():
 
         activate_hooks(
             communication_window=args.communication_window,
+            nameplates=args.nameplates,
             community_logging=args.community_logging,
         )
 
@@ -118,11 +113,11 @@ def main():
                 "This feature is unstable. You will not receive help if you've enabled this on your own. "
             )
 
-        if args.player_names or args.npc_names:
+        if args.nameplates:
             start_process(
-                name="Name scanner",
+                name="Nameplate scanner",
                 target=run_scans,
-                args=(args.player_names, args.npc_names),
+                args=(args.nameplates,),
             )
 
         log.success(

--- a/app/scans/manager.py
+++ b/app/scans/manager.py
@@ -10,12 +10,10 @@ from scans.player_names import scan_for_menu_ai_names
 import sys
 
 
-def run_scans(player_names: bool, npc_names: bool, ready_event):
+def run_scans(nameplates: bool, ready_event):
     """Run chosen scans.
 
-    :param player_names: Run player name scans.
-    :param npc_names: Run NPC name scans.
-    :param communication_window: Run adhoc scans.
+    :param nameplates: Whether to transliterate nameplate names.
     """
     # configure logging. this function runs in multiprocessing, so it does not
     # have the same access to the main log handler.
@@ -30,10 +28,9 @@ def run_scans(player_names: bool, npc_names: bool, ready_event):
 
     while True:
         try:
-            if player_names:
+            if nameplates:
                 scan_for_menu_ai_names(players)
                 scan_for_comm_names()
-            if npc_names:
                 scan_for_concierge_names(mytown_names)
         except UnicodeDecodeError:
             pass


### PR DESCRIPTION
Removing support for player names / npc names separately as an option as the nameplates hook does not distinguish between the two.