### PR TITLE
disable TLS when making calls to github.

### DIFF
--- a/app/common/update.py
+++ b/app/common/update.py
@@ -28,6 +28,7 @@ import re
 import requests
 import sys
 import time
+import urllib3
 import winreg
 
 
@@ -375,7 +376,12 @@ def download_file(url: str) -> requests.models.Response:
 
     while retries < max_retries:
         try:
-            response = requests.get(url)
+            # disabling TLS in general is an awful practice, but consumers of this application
+            # are not technical and troubleshooting certificate issues with users is both
+            # time consuming and exhausting. these SSL errors are primarily occurring specifically
+            # with github.
+            urllib3.disable_warnings()
+            response = requests.get(url, verify=False)
             response.raise_for_status()
             break
         except Exception as e:

--- a/app/updater.py
+++ b/app/updater.py
@@ -5,6 +5,7 @@ from zipfile import ZipFile as zip
 import glob
 import os
 import shutil
+import ssl
 import subprocess
 import sys
 
@@ -46,12 +47,20 @@ def kill_exe(name: str) -> None:
 
 
 def download_latest_zip():
+    # yes, this is not a great security practice, but consumers of this application
+    # are not technical and troubleshooting cert issues with non-technical
+    # users is both time consuming and exhausting.
     req = Request(CLARITY_URL)
-    data = urlopen(req, timeout=15)
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    data = urlopen(req, timeout=15, context=ctx)
+
     if data.status == 200:
         zfile = zip(BytesIO(data.read()))
     else:
         zfile = None
+
     return zfile
 
 


### PR DESCRIPTION
this is not a great security practice, but the support issues for troubleshooting user TLS issues has gotten out of hand for something out of my control. as the consumers of this application are not technical in nature, debugging TLS issues on a user's computer is near impossible. this disables TLS verification and downloads the file even if it fails.

TLS verification is still enabled for google/deepl calls at this time - unless it also becomes a problem.