### PR TITLE
refactor: look up dqxgame.exe process differently

### DIFF
--- a/app/updater.py
+++ b/app/updater.py
@@ -1,30 +1,65 @@
-from io import BytesIO
-from urllib.request import Request, urlopen
-from zipfile import ZipFile as zip
-
+import ctypes
+import ctypes.wintypes
 import glob
 import os
 import shutil
 import ssl
-import subprocess
 import sys
+from io import BytesIO
+from urllib.request import Request, urlopen
+from zipfile import ZipFile as zip
+
 
 CLARITY_URL = "https://github.com/dqx-translation-project/dqxclarity/releases/latest/download/dqxclarity.zip"
 
 
 def is_dqx_process_running():
-    """Return True if DQX is currently running."""
-    # This is difficult to do with native Python or ctypes as user locale settings
-    # vary widely across the globe, so decoding the stdout cannot be relied on.
-    # We will just check the exit code of a common Windows command to find this.
-    # tasklist does not produce an exit code on failed lookups, but find does.
-    call = 'TASKLIST /FI "imagename eq DQXGame.exe" | find "DQXGame" > nul'
+    """Return True if DQX is currently running.
+
+    Uses the Windows API directly with Unicode functions (Process32FirstW,
+    Process32NextW) to avoid locale/code page issues that occur when decoding
+    process names from subprocess output.
+    """
+
+    class PROCESSENTRY32W(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", ctypes.wintypes.DWORD),
+            ("cntUsage", ctypes.wintypes.DWORD),
+            ("th32ProcessID", ctypes.wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.POINTER(ctypes.c_ulong)),
+            ("th32ModuleID", ctypes.wintypes.DWORD),
+            ("cntThreads", ctypes.wintypes.DWORD),
+            ("th32ParentProcessID", ctypes.wintypes.DWORD),
+            ("pcPriClassBase", ctypes.c_long),
+            ("dwFlags", ctypes.wintypes.DWORD),
+            ("szExeFile", ctypes.c_wchar * 260),  # MAX_PATH, Unicode
+        ]
+
+    TH32CS_SNAPPROCESS = 0x00000002
+    INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+    kernel32 = ctypes.windll.kernel32
+
+    snapshot = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if snapshot == INVALID_HANDLE_VALUE:
+        return False
 
     try:
-        subprocess.check_call(call, shell=True)
-        return True
-    except subprocess.CalledProcessError:
+        entry = PROCESSENTRY32W()
+        entry.dwSize = ctypes.sizeof(PROCESSENTRY32W)
+
+        if not kernel32.Process32FirstW(snapshot, ctypes.byref(entry)):
+            return False
+
+        while True:
+            if entry.szExeFile.lower() == "dqxgame.exe":
+                return True
+            if not kernel32.Process32NextW(snapshot, ctypes.byref(entry)):
+                break
+
         return False
+    finally:
+        kernel32.CloseHandle(snapshot)
 
 
 def is_steam_deck() -> bool:
@@ -32,9 +67,7 @@ def is_steam_deck() -> bool:
 
     :returns: Returns True if yes. Else, False.
     """
-    if os.environ.get("SteamDeck") == "1":
-        return True
-    return False
+    return os.environ.get("SteamDeck") == "1"  # noqa: SIM112
 
 
 def kill_exe(name: str) -> None:


### PR DESCRIPTION
Instead of checking if the game process is running with `tasklist` / `find`, use ctypes calls. Use `W` modes to support multi-language locales.