### PR TITLE
updater: make self-contained, add --release flag for testing

### DIFF
--- a/app/common/update.py
+++ b/app/common/update.py
@@ -4,7 +4,6 @@ import os
 import re
 import requests
 import sys
-import tempfile
 import time
 import urllib3
 from common.config import UserConfig
@@ -120,13 +119,14 @@ def read_custom_json_and_import(name: str, data: str) -> None:
     db_query(query)
 
 
-def check_for_updates(update: bool) -> None:
+def check_for_updates(update: bool, test_release: str = None) -> None:
     """Checks to see if Clarity is running the latest version of itself. If
     not, will launch updater.py and exit.
 
     :param update: Whether or not to update after checking for updates.
+    :param test_release: If set, skip version comparison and force-install this
+        specific release tag (e.g. 'v1.2.3'). For pre-release testing only.
     """
-    log.info("Checking dqxclarity repo for updates...")
     if not os.path.exists("version.update"):
         log.warning("Couldn't determine current version of dqxclarity. Running as is.")
         return
@@ -134,18 +134,26 @@ def check_for_updates(update: bool) -> None:
     with open("version.update") as file:
         cur_ver = file.read().strip()
 
-    github_request = download_file(GITHUB_CLARITY_VERSION_UPDATE_URL)
+    if test_release is not None:
+        tag_arg = test_release if test_release.startswith("v") else f"v{test_release}"
+        log.warning(f"Test mode: force-installing release {tag_arg}.")
+        release_url = f"https://api.github.com/repos/dqx-translation-project/dqxclarity/releases/tags/{tag_arg}"
+    else:
+        log.info("Checking dqxclarity repo for updates...")
+        release_url = GITHUB_CLARITY_VERSION_UPDATE_URL
+
+    github_request = download_file(release_url)
 
     try:
         release = github_request.json()
         tag = release["tag_name"]
         new_ver = tag[1:]
 
-        if new_ver == cur_ver:
-            log.success(f"Up to date. Version: {cur_ver}")
-            return
-
-        log.warning(f"Out of date! {cur_ver} -> {new_ver}")
+        if test_release is None:
+            if new_ver == cur_ver:
+                log.success(f"Up to date. Version: {cur_ver}")
+                return
+            log.warning(f"Out of date! {cur_ver} -> {new_ver}")
 
         if not update:
             return
@@ -159,28 +167,9 @@ def check_for_updates(update: bool) -> None:
         with open("updater.py", "w+b") as f:
             f.write(response.content)
 
-        # Write release notes to a temp file for the updater to display
-        notes_file = None
-        release_notes = release.get("body", "")
-        if release_notes:
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, encoding="utf-8") as f:
-                f.write(release_notes)
-                notes_file = f.name
-
-        zip_url = f"https://github.com/dqx-translation-project/dqxclarity/releases/download/{tag}/dqxclarity.zip"
-
-        cmd = [
-            sys.executable,
-            "./updater.py",
-            "--zip-url",
-            zip_url,
-            "--cur-version",
-            cur_ver,
-            "--new-version",
-            new_ver,
-        ]
-        if notes_file:
-            cmd += ["--release-notes-file", notes_file]
+        cmd = [sys.executable, "./updater.py"]
+        if test_release is not None:
+            cmd += ["--release", tag]
 
         log.info("Launching updater.")
         Popen(cmd)

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,12 @@ def parse_arguments():
         help="Purges all rows from the sqlite dialog table, which is used for caching translations.",
     )
     parser.add_argument("-v", "--debug", action="store_true", help="Enable debug level logging.")
+    parser.add_argument(
+        "-t",
+        "--test-release",
+        metavar="TAG",
+        help="Force-install a specific release version for testing (e.g. v1.2.3). Bypasses the version check.",
+    )
 
     return parser.parse_args()
 
@@ -81,7 +87,9 @@ def main():
     if args.update_dat:
         log.info("Updating DAT mod.")
         download_dat_files()
-    if not args.disable_update_check:
+    if args.test_release:
+        check_for_updates(update=True, test_release=args.test_release)
+    elif not args.disable_update_check:
         log.info("Updating custom text in db.")
         check_for_updates(update=True)
         download_custom_files()

--- a/app/tests/test_updater.py
+++ b/app/tests/test_updater.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 import unittest
 import zipfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -66,48 +66,59 @@ class TestStripMarkdown(unittest.TestCase):
 
 
 class TestUpdaterMain(unittest.TestCase):
-    # Each test calls _run_main(), which patches out everything that would block
-    # or touch the live system: DQX process check, exe kills, and the input()
-    # prompt at the end. Tests use a real temp work_dir and a real local zip so
-    # the actual file extraction and copy logic runs unpatched.
+    # Each test calls _run_main(), which patches out everything that touches the
+    # network or blocks: fetch_release_info, download_zip, process checks, exe
+    # kills, and the input() prompt at the end. Tests use a real temp work_dir
+    # and a real local zip so the actual file extraction and copy logic runs
+    # unpatched.
 
     def setUp(self):
         # Fresh temp work dir and zip file for each test
         self.work_dir = tempfile.mkdtemp(prefix="dqxclarity_test_work_")
         self.zip_fd, self.zip_path = tempfile.mkstemp(suffix=".zip")
         os.close(self.zip_fd)
+        # Write version.update so cur_ver can be read
+        with open(os.path.join(self.work_dir, "version.update"), "w") as f:
+            f.write("1.0.0")
 
     def tearDown(self):
         shutil.rmtree(self.work_dir, ignore_errors=True)
         if os.path.exists(self.zip_path):
             os.remove(self.zip_path)
 
-    def _run_main(self, extra_args=None):
-        """Invoke main() with --local-zip and --work-dir pointing at test fixtures.
-        Patches sys.argv so argparse reads our test args, and patches everything
-        that would block (input) or touch the live OS (process checks, kill_exe)."""
-        argv = [
-            "updater.py",
-            "--local-zip",
-            self.zip_path,
-            "--work-dir",
-            self.work_dir,
-            "--cur-version",
-            "1.0.0",
-            "--new-version",
-            "1.1.0",
-        ]
+    def _run_main(self, extra_args=None, release_notes="", fetch_side_effect=None, download_side_effect=None):
+        """Invoke main() with all network I/O patched and work-dir pointed at
+        the test fixture. Returns the mock_input so callers can inspect the
+        final prompt if needed."""
+        fake_release = {"tag_name": "v1.1.0", "body": release_notes}
+        mock_input = MagicMock()
+
+        argv = ["updater.py", "--work-dir", self.work_dir]
         if extra_args:
             argv += extra_args
+
+        if fetch_side_effect:
+            fetch_patch = patch("updater.fetch_release_info", side_effect=fetch_side_effect)
+        else:
+            fetch_patch = patch("updater.fetch_release_info", return_value=fake_release)
+
+        if download_side_effect:
+            download_patch = patch("updater.download_zip", side_effect=download_side_effect)
+        else:
+            download_patch = patch("updater.download_zip", return_value=zipfile.ZipFile(self.zip_path))
 
         with (
             patch("sys.argv", argv),
             patch("updater.is_dqx_process_running", return_value=False),
             patch("updater.is_steam_deck", return_value=False),
             patch("updater.kill_exe"),
-            patch("builtins.input"),
+            fetch_patch,
+            download_patch,
+            patch("builtins.input", mock_input),
         ):
             main()
+
+        return mock_input
 
     def test_files_copied_to_work_dir(self):
         # Verify new files from the zip land in work_dir at the right paths
@@ -178,88 +189,56 @@ class TestUpdaterMain(unittest.TestCase):
         self.assertFalse(os.path.exists(venv_path))
 
     def test_release_notes_displayed(self):
-        # Release notes are written to a temp file by check_for_updates and passed
-        # via --release-notes-file. Verify the stripped content appears in output.
-        fd, notes_file = tempfile.mkstemp(suffix=".txt")
-        os.close(fd)
-        with open(notes_file, "w") as f:
-            f.write("## What's new\n\n- Fixed a bug")
-
+        # Release notes come from the fetch_release_info response body.
+        # Verify the stripped content appears in output.
         make_zip(self.zip_path, {"app/main.py": "x"})
 
         with patch("builtins.print") as mock_print:
-            self._run_main(extra_args=["--release-notes-file", notes_file])
+            self._run_main(release_notes="## What's new\n\n- Fixed a bug")
 
         printed = " ".join(str(c) for call in mock_print.call_args_list for c in call[0])
         self.assertIn("What's new", printed)
         self.assertIn("Fixed a bug", printed)
 
-    def test_release_notes_file_cleaned_up(self):
-        # The temp notes file should be deleted after being read
-        fd, notes_file = tempfile.mkstemp(suffix=".txt")
-        os.close(fd)
-        with open(notes_file, "w") as f:
-            f.write("some notes")
-
-        make_zip(self.zip_path, {"app/main.py": "x"})
-        self._run_main(extra_args=["--release-notes-file", notes_file])
-
-        self.assertFalse(os.path.exists(notes_file))
-
     def test_version_string_in_success_message(self):
-        # Both old and new versions should appear in the final input() prompt
+        # cur_ver comes from version.update (written in setUp as "1.0.0").
+        # new_ver comes from the fake release tag "v1.1.0".
         make_zip(self.zip_path, {"app/main.py": "x"})
 
-        with (
-            patch("builtins.input") as mock_input,
-            patch(
-                "sys.argv",
-                [
-                    "updater.py",
-                    "--local-zip",
-                    self.zip_path,
-                    "--work-dir",
-                    self.work_dir,
-                    "--cur-version",
-                    "1.0.0",
-                    "--new-version",
-                    "1.1.0",
-                ],
-            ),
-            patch("updater.is_dqx_process_running", return_value=False),
-            patch("updater.is_steam_deck", return_value=False),
-            patch("updater.kill_exe"),
-        ):
-            main()
+        mock_input = self._run_main()
 
         call_arg = mock_input.call_args[0][0]
         self.assertIn("1.0.0", call_arg)
         self.assertIn("1.1.0", call_arg)
 
-    def test_invalid_zip_exits(self):
-        # A corrupt zip should fail gracefully and call sys.exit(1)
-        with open(self.zip_path, "w") as f:
-            f.write("not a zip")
+    def test_specific_release_arg_passed_to_fetch(self):
+        # When --release is supplied, fetch_release_info should receive that tag.
+        make_zip(self.zip_path, {"app/main.py": "x"})
 
-        with self.assertRaises(SystemExit):
-            self._run_main()
-
-    def test_missing_zip_exits(self):
-        # A path that doesn't exist should fail gracefully and call sys.exit(1)
         with (
-            self.assertRaises(SystemExit),
-            patch("sys.argv", ["updater.py", "--local-zip", "/nonexistent.zip", "--work-dir", self.work_dir]),
+            patch("updater.fetch_release_info", return_value={"tag_name": "v1.0.5", "body": ""}) as mock_fetch,
+            patch("updater.download_zip", return_value=zipfile.ZipFile(self.zip_path)),
             patch("updater.is_dqx_process_running", return_value=False),
             patch("updater.is_steam_deck", return_value=False),
             patch("updater.kill_exe"),
             patch("builtins.input"),
+            patch("sys.argv", ["updater.py", "--work-dir", self.work_dir, "--release", "v1.0.5"]),
         ):
             main()
 
-    def test_no_source_arg_exits(self):
-        # Calling the updater without --zip-url or --local-zip should exit immediately
-        with self.assertRaises(SystemExit), patch("sys.argv", ["updater.py", "--work-dir", self.work_dir]):
-            main()
+        mock_fetch.assert_called_once_with("v1.0.5")
+
+    def test_fetch_failure_exits(self):
+        # A failure fetching release info should exit gracefully
+        make_zip(self.zip_path, {"app/main.py": "x"})
+        with self.assertRaises(SystemExit):
+            self._run_main(fetch_side_effect=RuntimeError("HTTP 404"))
+
+    def test_zip_download_failure_exits(self):
+        # A failure downloading the zip should exit gracefully
+        make_zip(self.zip_path, {"app/main.py": "x"})
+        with self.assertRaises(SystemExit):
+            self._run_main(download_side_effect=RuntimeError("connection error"))
 
 
 if __name__ == "__main__":

--- a/app/tests/test_updater.py
+++ b/app/tests/test_updater.py
@@ -102,21 +102,27 @@ class TestUpdaterMain(unittest.TestCase):
         else:
             fetch_patch = patch("updater.fetch_release_info", return_value=fake_release)
 
+        zip_obj = None
         if download_side_effect:
             download_patch = patch("updater.download_zip", side_effect=download_side_effect)
         else:
-            download_patch = patch("updater.download_zip", return_value=zipfile.ZipFile(self.zip_path))
+            zip_obj = zipfile.ZipFile(self.zip_path)
+            download_patch = patch("updater.download_zip", return_value=zip_obj)
 
-        with (
-            patch("sys.argv", argv),
-            patch("updater.is_dqx_process_running", return_value=False),
-            patch("updater.is_steam_deck", return_value=False),
-            patch("updater.kill_exe"),
-            fetch_patch,
-            download_patch,
-            patch("builtins.input", mock_input),
-        ):
-            main()
+        try:
+            with (
+                patch("sys.argv", argv),
+                patch("updater.is_dqx_process_running", return_value=False),
+                patch("updater.is_steam_deck", return_value=False),
+                patch("updater.kill_exe"),
+                fetch_patch,
+                download_patch,
+                patch("builtins.input", mock_input),
+            ):
+                main()
+        finally:
+            if zip_obj is not None:
+                zip_obj.close()
 
         return mock_input
 
@@ -214,17 +220,21 @@ class TestUpdaterMain(unittest.TestCase):
     def test_specific_release_arg_passed_to_fetch(self):
         # When --release is supplied, fetch_release_info should receive that tag.
         make_zip(self.zip_path, {"app/main.py": "x"})
+        zip_obj = zipfile.ZipFile(self.zip_path)
 
-        with (
-            patch("updater.fetch_release_info", return_value={"tag_name": "v1.0.5", "body": ""}) as mock_fetch,
-            patch("updater.download_zip", return_value=zipfile.ZipFile(self.zip_path)),
-            patch("updater.is_dqx_process_running", return_value=False),
-            patch("updater.is_steam_deck", return_value=False),
-            patch("updater.kill_exe"),
-            patch("builtins.input"),
-            patch("sys.argv", ["updater.py", "--work-dir", self.work_dir, "--release", "v1.0.5"]),
-        ):
-            main()
+        try:
+            with (
+                patch("updater.fetch_release_info", return_value={"tag_name": "v1.0.5", "body": ""}) as mock_fetch,
+                patch("updater.download_zip", return_value=zip_obj),
+                patch("updater.is_dqx_process_running", return_value=False),
+                patch("updater.is_steam_deck", return_value=False),
+                patch("updater.kill_exe"),
+                patch("builtins.input"),
+                patch("sys.argv", ["updater.py", "--work-dir", self.work_dir, "--release", "v1.0.5"]),
+            ):
+                main()
+        finally:
+            zip_obj.close()
 
         mock_fetch.assert_called_once_with("v1.0.5")
 

--- a/app/updater.py
+++ b/app/updater.py
@@ -2,6 +2,7 @@ import argparse
 import contextlib
 import ctypes
 import ctypes.wintypes
+import json
 import os
 import re
 import shutil
@@ -72,6 +73,28 @@ def kill_exe(name: str) -> None:
     os.system(f"taskkill /f /im {name} >nul 2>&1")
 
 
+def fetch_release_info(tag: str = None) -> dict:
+    """Fetch release metadata from GitHub.
+
+    If tag is provided, fetches that specific release; otherwise fetches the
+    latest published release.
+    """
+    if tag:
+        tag = tag if tag.startswith("v") else f"v{tag}"
+        url = f"https://api.github.com/repos/dqx-translation-project/dqxclarity/releases/tags/{tag}"
+    else:
+        url = "https://api.github.com/repos/dqx-translation-project/dqxclarity/releases/latest"
+
+    req = Request(url)
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    data = urlopen(req, timeout=30, context=ctx)
+    if data.status != 200:
+        raise RuntimeError(f"HTTP {data.status} fetching release info")
+    return json.loads(data.read())
+
+
 def download_zip(url: str) -> ZipFile:
     print("Downloading update...")
     req = Request(url)
@@ -102,19 +125,19 @@ def strip_markdown(text: str) -> str:
 
 def main():
     parser = argparse.ArgumentParser(description="dqxclarity updater")
-    parser.add_argument("--zip-url", help="URL to download the release zip from")
-    parser.add_argument("--local-zip", help="Path to a local zip file (for testing)")
+    parser.add_argument(
+        "--release", metavar="TAG", help="Install a specific release version (e.g. v1.2.3) instead of the latest."
+    )
     parser.add_argument("--work-dir", help="Directory to update (defaults to directory of this script)")
-    parser.add_argument("--cur-version", help="Current installed version")
-    parser.add_argument("--new-version", help="New version being installed")
-    parser.add_argument("--release-notes-file", help="Path to a temp file containing release notes")
     args = parser.parse_args()
 
-    if not args.zip_url and not args.local_zip:
-        print("Error: must provide --zip-url or --local-zip.")
-        sys.exit(1)
-
     work_dir = os.path.abspath(args.work_dir or os.path.split(os.path.abspath(__file__))[0])
+
+    version_file = os.path.join(work_dir, "version.update")
+    cur_ver = None
+    if os.path.exists(version_file):
+        with open(version_file) as f:
+            cur_ver = f.read().strip()
 
     if is_dqx_process_running():
         input(
@@ -132,11 +155,12 @@ def main():
     kill_exe("DQXClarity.exe")
 
     try:
-        if args.local_zip:
-            print(f"Using local zip: {args.local_zip}")
-            z_data = ZipFile(args.local_zip)
-        else:
-            z_data = download_zip(args.zip_url)
+        release = fetch_release_info(args.release)
+        tag = release["tag_name"]
+        new_ver = tag[1:]
+        zip_url = f"https://github.com/dqx-translation-project/dqxclarity/releases/download/{tag}/dqxclarity.zip"
+        z_data = download_zip(zip_url)
+        release_notes = strip_markdown(release.get("body", "") or "")
     except Exception as e:
         input(
             "Failed to download the latest update. Your existing install is unchanged.\n"
@@ -213,28 +237,16 @@ def main():
     if os.path.exists(venv_path):
         shutil.rmtree(venv_path, ignore_errors=True)
 
-    # Read and display release notes, then clean up the temp file
-    release_notes = ""
-    if args.release_notes_file and os.path.exists(args.release_notes_file):
-        try:
-            with open(args.release_notes_file, encoding="utf-8") as f:
-                release_notes = strip_markdown(f.read())
-        except Exception:
-            pass
-        finally:
-            with contextlib.suppress(OSError):
-                os.remove(args.release_notes_file)
-
-    if args.cur_version and args.new_version:
-        version_str = f"({args.cur_version} -> {args.new_version})"
-    elif args.new_version:
-        version_str = f"(v{args.new_version})"
+    if cur_ver and new_ver:
+        version_str = f"({cur_ver} -> {new_ver})"
+    elif new_ver:
+        version_str = f"(v{new_ver})"
     else:
         version_str = ""
 
     print()
-    if release_notes and args.new_version:
-        header = f"=== What's new in v{args.new_version} ==="
+    if release_notes and new_ver:
+        header = f"=== What's new in v{new_ver} ==="
         print(header)
         print()
         print(release_notes)


### PR DESCRIPTION
updater.py now fetches release info from the GitHub API itself (zip URL, release notes, version) instead of requiring the caller to pass them as args. The only args remaining are --release TAG (optional, fetches a specific release instead of latest) and --work-dir (for test isolation).

main.py gains --test-release TAG which check_for_updates passes through to the spawned updater as --release, allowing a specific release to be tested before it goes live without pushing a new tag. The temp notes file and all version/zip args are removed from the spawn command.