### PR TITLE
run_clarity.ps1: fix long-standing venv detection bug

### DIFF
--- a/app/run_clarity.ps1
+++ b/app/run_clarity.ps1
@@ -213,8 +213,11 @@ if (!$PythonInstallPath) {
     }
 }
 
-# check if the user already has a virtual environment folder
-if (-not (Test-Path -Path "venv")) {
+# check if the user already has a usable virtual environment.
+# checking for the executables (not just the directory) guards against a partial
+# delete left behind by the updater when files were locked during rmtree.
+if (-not (Test-Path -Path "venv\Scripts\python.exe") -or -not (Test-Path -Path "venv\Scripts\activate")) {
+    RemoveFile "venv"
     LogWrite "Creating virtual environment."
     $venvJob = Start-Job -ScriptBlock {
         param($pythonPath, $dir)


### PR DESCRIPTION
`Test-Path "venv"` was used to decide whether to create a virtual environment, but `shutil.rmtree(..., ignore_errors=True)` on Windows can leave the directory behind when files are locked (e.g. by antivirus) — causing the script to skip venv creation even though the executables inside are gone.

now validates that both `venv\Scripts\python.exe` and `venv\Scripts\activate` exist before considering the venv usable. if either is missing, the leftover directory is cleaned up before recreating the venv from scratch.