### PR TITLE
fix: don't package dotnet9

### DIFF
--- a/launcher/Taskfile.yml
+++ b/launcher/Taskfile.yml
@@ -9,7 +9,7 @@ tasks:
   publish:
     desc: publish a self-contained single-file exe for win-x64
     cmds:
-      - dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+      - dotnet publish -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true
 
   clean:
     desc: remove build artifacts


### PR DESCRIPTION
packaging causes an issue when unpacking a single exe on crossover.

this has a side effects of users needing to install dotnet9 runtime, but don't see this as a big problem as the exe will prompt the user to download it if they don't have it.