### PR TITLE
don't translate english strings with japanese names

### DIFF
--- a/app/common/translate.py
+++ b/app/common/translate.py
@@ -38,7 +38,7 @@ class Translator:
         if Translator.glossary is None:
             Translator.glossary = generate_glossary_dict()
 
-    def __glossify(self, text):
+    def glossify(self, text):
         for ja in Translator.glossary:
             en = Translator.glossary[ja]
 
@@ -218,7 +218,7 @@ class Translator:
             were given.
         """
         for i, phrase in enumerate(text):
-            text[i] = self.__glossify(phrase)
+            text[i] = self.glossify(phrase)
 
         if Translator.service == "deepl":
             translator = DeepLTranslate(Translator.api_key)
@@ -328,7 +328,7 @@ class Translator:
         output = self.__swap_placeholder_tags(output)
 
         # pass string through our glossary to replace any common words
-        output = self.__glossify(output)
+        output = self.glossify(output)
 
         # re-assign this string. this is now our "pristine" string we'll be using later.
         pristine_str = output

--- a/app/hooking/hooks/dialogue.py
+++ b/app/hooking/hooks/dialogue.py
@@ -3,7 +3,7 @@ from common.config import UserConfig
 from common.constants import COMMUNITY_STRING_API_URL
 from common.db_ops import init_db, search_bad_strings, sql_read
 from common.measure import measure_duration
-from common.translate import Translator, get_player_name, is_text_japanese
+from common.translate import Translator, get_player_name, is_text_japanese, transliterate_player_name
 from loguru import logger as log
 
 
@@ -46,7 +46,26 @@ def dialogue_replacement(original_text: str, npc_name: str = "No_NPC") -> str:
     if db_result:
         return db_result
 
-    # translate the text
+    # in cutscenes or places where the player's name or sibling is expanded to japanese by in-game variable expansion,
+    # but everything else is non-Japanese, this will fail the JP check and force a translation. this causes us to translate
+    # text we didn't need to and tends to make the text worse.
+    # this first applies the glossary strings over the sentence as the user may have created overrides for their own names.
+    # in case they didn't, we also try to replace the player's Japanese name with a transliterated version. this should fix
+    # the inconsistencies where the string looks like it needs to be translated because there's Japanese within it. this
+    # should also handle issues where the player/sibling name is not translated in dialogue.
+    glossified = _translator.glossify(original_text)
+
+    player, sibling = get_player_name()
+    player_trl = transliterate_player_name(player)
+    sibling_trl = transliterate_player_name(sibling)
+
+    glossified = glossified.replace(player, player_trl)
+    glossified = glossified.replace(sibling, sibling_trl)
+
+    if not is_text_japanese(glossified):
+        return glossified
+
+    # all checks failed - this text should definitely be Japanese and eligible for translation.
     translated_text = _translator.translate(text=original_text, wrap_width=46)
 
     if translated_text:


### PR DESCRIPTION
this solves a case where the game expands something like <%HERO%> (not actual var name) to the player's japanese name. this causes strings that are fully translated, but with a name in japanese to end up being seen as something that needs to be translated. this commonly occurs in cutscenes, which ends up sending english strings through a japanese translation - screwing up the translation and also wasting effort.