### PR TITLE
pin cryptography to an older version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
     "configparser==7.2.0",
-    "cryptography<46",
+    "cryptography==48.0.1",  # do not upgrade this, 49.0.0 no longer supports 32-bit python
     "deepl==1.29.0",
     "frida==17.5.2",
     "google-api-core==2.30.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
     "configparser==7.2.0",
+    "cryptography<46",
     "deepl==1.29.0",
     "frida==17.5.2",
     "google-api-core==2.30.3",


### PR DESCRIPTION
49.0.0 is causing problems for people due to build issues.

https://github.com/pyca/cryptography/issues/15037