### PR TITLE
Fix corner_text hook signature for DQX 8.0 and refresh hook disasm comments

### DIFF
--- a/app/hooking/hook.py
+++ b/app/hooking/hook.py
@@ -108,7 +108,7 @@ HOOKS = {
     "default": [
         FridaHook(
             name="corner_text",
-            signature="55 8B EC 8B 45 ?? 83 EC ?? 53 8B 5D ?? 56 8B F1 57 85 C0",
+            signature="55 8B EC 83 EC ?? 8B 45 14 53 56 8B 75 10 89 4D ?? 89 45 ?? 57 85 F6",
             script_file="corner_text.ts",
             message_handler=corner_text_on_message,
             enabled=True,

--- a/app/hooking/scripts/blowfish_logger.ts
+++ b/app/hooking/scripts/blowfish_logger.ts
@@ -1,4 +1,4 @@
-// hook for logging blowfish decryption keys.
+// hook for logging blowfish decryption keys. (8.0: DQXGame.exe+104BF0)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
@@ -6,9 +6,9 @@
     57                    - push edi
     8B 79 24              - mov edi,[ecx+24]
     85 FF                 - test edi,edi
-    74 59                 - je DQXGame.exe+104265
+    74 59                 - je DQXGame.exe+104C55
     83 7D 08 00           - cmp dword ptr [ebp+08],00
-    74 53                 - je DQXGame.exe+104265
+    74 53                 - je DQXGame.exe+104C55
     8B 45 0C              - mov eax,[ebp+0C]
 
 */

--- a/app/hooking/scripts/corner_text.ts
+++ b/app/hooking/scripts/corner_text.ts
@@ -1,16 +1,22 @@
-// hook for corner text.
+// hook for corner text. (8.0: DQXGame.exe+7416D0)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
-    8B 45 10              - mov eax,[ebp+10]
-    83 EC 14              - sub esp,14
+    83 EC 34              - sub esp,34
+    8B 45 14              - mov eax,[ebp+14]
     53                    - push ebx
-    8B 5D 14              - mov ebx,[ebp+14]
     56                    - push esi
-    8B F1                 - mov esi,ecx
+    8B 75 10              - mov esi,[ebp+10]      ; esi = text (args[2])
+    89 4D F4              - mov [ebp-0C],ecx      ; this
+    89 45 D8              - mov [ebp-28],eax
     57                    - push edi
-    85 C0                 - test eax,eax
-    0F84 16020000         - je DQXGame.exe+717F9F
+    85 F6                 - test esi,esi
+    0F84 21040000         - je DQXGame.exe+741B0E
+
+    note: prior to the 8.0 patch this function used a different register
+    allocation (text in eax, this in esi). it was recompiled and the old
+    signature stopped matching. text pointer is still the 3rd stack arg
+    (args[2]).
 
     top-right corner text from NPCs. seen primarily in v5/v6.
     how it was found:

--- a/app/hooking/scripts/dialogue.ts
+++ b/app/hooking/scripts/dialogue.ts
@@ -1,11 +1,11 @@
-// hook for dialogue text
+// hook for dialogue text (8.0: DQXGame.exe+755F50)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
     56                    - push esi
     8B F1                 - mov esi,ecx
     80 BE EC000000 00     - cmp byte ptr [esi+000000EC],00
-    74 07                 - je DQXGame.exe+72B7E6
+    74 07                 - je DQXGame.exe+755F66
     C6 86 ED000000 01     - mov byte ptr [esi+000000ED],01
     FF 75 18              - push [ebp+18]
     8B 45 0C              - mov eax,[ebp+0C]

--- a/app/hooking/scripts/hash_logger.ts
+++ b/app/hooking/scripts/hash_logger.ts
@@ -1,10 +1,10 @@
-// hook for logging hashed filenames.
+// hook for logging hashed filenames. (8.0: DQXGame.exe+1043C0)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
     8B 55 08              - mov edx,[ebp+08]
     85 D2                 - test edx,edx
-    75 04                 - jne DQXGame.exe+1039DE
+    75 04                 - jne DQXGame.exe+1043CE
     33 C0                 - xor eax,eax
     5D                    - pop ebp
     C3                    - ret

--- a/app/hooking/scripts/nameplates.ts
+++ b/app/hooking/scripts/nameplates.ts
@@ -1,11 +1,11 @@
-// hook for entity nameplates.
+// hook for entity nameplates. (8.0: DQXGame.exe+14BB90)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
     56                    - push esi
     8B B1 88010000        - mov esi,[ecx+00000188]
     85 F6                 - test esi,esi
-    74 16                 - je DQXGame.exe+141B54
+    74 16                 - je DQXGame.exe+142BB4
     8B 45 08              - mov eax,[ebp+08]
     8D 4E 08              - lea ecx,[esi+08]
     51                    - push ecx

--- a/app/hooking/scripts/network_text.ts
+++ b/app/hooking/scripts/network_text.ts
@@ -1,13 +1,13 @@
-// hook for network text template string replacements.
+// hook for network text template string replacements. (8.0: DQXGame.exe+53A750)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
     81 EC DC030000        - sub esp,000003DC
-    A1 40C5F701           - mov eax,[DQXGame.exe+1C3C540]
+    A1 C0211502           - mov eax,[DQXGame.exe+1CA21C0]   ; /GS cookie
     33 C5                 - xor eax,ebp
     89 45 FC              - mov [ebp-04],eax
     8B 45 14              - mov eax,[ebp+14]
-    8B 0D C083FA01        - mov ecx,[DQXGame.exe+1C683C0]
+    8B 0D D0E41702        - mov ecx,[DQXGame.exe+1CCE4D0]
     89 45 D8              - mov [ebp-28],eax
     64 A1 2C000000        - mov eax,fs:[0000002C]
     53                    - push ebx

--- a/app/hooking/scripts/player.ts
+++ b/app/hooking/scripts/player.ts
@@ -1,5 +1,6 @@
 // hook for player login - initializes database with player/sibling data.
 // this is triggered when the player logs in with their character.
+// (8.0: DQXGame.exe+4F4290)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
@@ -8,14 +9,14 @@
     57                    - push edi
     8B 46 58              - mov eax,[esi+58]
     85 C0                 - test eax,eax
-    74 10                 - je DQXGame.exe+422C8E
+    74 10                 - je DQXGame.exe+4F42AE
     50                    - push eax
-    E8 9CAEC1FF           - call DQXGame.exe+3DB20
+    E8 6CC7BCFF           - call mem_deleteIfNotNull
     83 C4 04              - add esp,04
     C7 46 58 00000000     - mov [esi+58],00000000
     6A 02                 - push 02
-    68 B0000000           - push 000000B0
-    E8 F6ADC1FF           - call DQXGame.exe+3DA90
+    68 B8000000           - push 000000B8           ; struct grew 0xB0 -> 0xB8 in 8.0
+    E8 36C7BCFF           - call <allocator>
 */
 (function() {
     const hookName = '{{HOOK_NAME}}';

--- a/app/hooking/scripts/quest.ts
+++ b/app/hooking/scripts/quest.ts
@@ -1,4 +1,4 @@
-// hook for translating a quest.
+// hook for translating a quest. (8.0: prologue DQXGame.exe+24B030, sig match at +24B145)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp

--- a/app/hooking/scripts/walkthrough.ts
+++ b/app/hooking/scripts/walkthrough.ts
@@ -1,9 +1,9 @@
-// hook for walkthrough text replacements.
+// hook for walkthrough text replacements. (8.0: DQXGame.exe+2E3030)
 /*
     55                    - push ebp
     8B EC                 - mov ebp,esp
     83 EC 40              - sub esp,40
-    8B 15 90C2F901        - mov edx,[DQXGame.exe+1C5C290]
+    8B 15 C8201702        - mov edx,[DQXGame.exe+1CC20C8]
     53                    - push ebx
     8B D9                 - mov ebx,ecx
     89 5D FC              - mov [ebp-04],ebx
@@ -12,14 +12,14 @@
     85 D2                 - test edx,edx
     ...
     ...
- >> E8 437FFFFF           - call DQXGame.exe+2D59E0
+ >> E8 337FFFFF           - call DQXGame.exe+2DAFA0   ; <- signature anchors here, callee hooked
  >> 8D B8 EC000000        - lea edi,[eax+000000EC]
     8B CF                 - mov ecx,edi
     8D 51 01              - lea edx,[ecx+01]
     8A 01                 - mov al,[ecx]
     41                    - inc ecx
     84 C0                 - test al,al
-    75 F9                 - jne DQXGame.exe+2DDAA8
+    75 F9                 - jne DQXGame.exe+2E3078
     2B CA                 - sub ecx,edx
 
     to find this, search for walkthrough text:


### PR DESCRIPTION
## Summary

Verified every Frida hook signature against the DQX **8.0** client and fixed the one that broke.

- **corner_text** was the only broken hook. The function still exists but was recompiled in 8.0 with a different register allocation (the text arg moved `eax`→`esi`, `this` spilled to `[ebp-0xc]`), so the old AOB couldn't match. Replaced it with a signature anchored on the new prologue, confirmed unique in 8.0.
- The other 8 signatures (`network_text`, `player`, `nameplates`, `dialogue`, `quest`, `walkthrough`, `hash_logger`, `blowfish_logger`) plus `mem_chr_trigger` still resolve **uniquely** in 8.0 — no signature changes needed.
- Refreshed the disassembly comment blocks in each hook script to match the current 8.0 bytes and `DQXGame.exe+RVA` targets. Notable byte drift: `player` struct alloc grew `0xB0`→`0xB8`, and relocated globals in `network_text` / `walkthrough`.

Hook *logic* (arg indices, struct offsets) was verified consistent with 8.0 and left unchanged.

## Note

The new corner_text signature is statically verified (unique match on the correct function), but has **not** yet been exercised against a running 8.0 client. Worth a live smoke-test (the Quest 764 loom repro documented in `corner_text.ts`) before relying on it.
