### PR TITLE
Make DragonHook a manual add/remove instead of auto-injecting version.dll

### DIFF
--- a/launcher/Models/AppConfig.cs
+++ b/launcher/Models/AppConfig.cs
@@ -13,7 +13,6 @@ public class LauncherConfig
     public string Theme { get; set; } = "rosie";
     public bool SeenWelcomeMessage { get; set; }
     public bool BannerCollapsed { get; set; }
-    public bool LanguagePackSupport { get; set; }
     public bool LanguagePackFirstRunDone { get; set; }
     public bool AutomaticLanguagePackUpdates { get; set; }
     public List<string> ActiveLanguagePacks { get; set; } = [];

--- a/launcher/Services/ConfigService.cs
+++ b/launcher/Services/ConfigService.cs
@@ -188,8 +188,6 @@ public class ConfigService
                 Theme                    = l.GetValueOrDefault("theme") ?? "rosie",
                 SeenWelcomeMessage       = ToBool(l.GetValueOrDefault("seenwelcomemessage")),
                 BannerCollapsed          = ToBool(l.GetValueOrDefault("bannercollapsed")),
-                // Default ON for new configs (key absent); respect an explicit False once set.
-                LanguagePackSupport      = l.ContainsKey("languagepacksupport") ? ToBool(l["languagepacksupport"]) : true,
                 LanguagePackFirstRunDone = ToBool(l.GetValueOrDefault("languagepackfirstrundone")),
                 AutomaticLanguagePackUpdates = l.ContainsKey("automaticlanguagepackupdates") ? ToBool(l["automaticlanguagepackupdates"]) : true,
                 ActiveLanguagePacks      = (l.GetValueOrDefault("activelanguagepacks") ?? "")
@@ -264,7 +262,6 @@ public class ConfigService
         WriteKv(sb, "theme",                    launcher.Theme);
         WriteKv(sb, "seenwelcomemessage",       seenWelcome);
         WriteKv(sb, "bannercollapsed",          bannerCollapsed);
-        WriteKv(sb, "languagepacksupport",      BoolToIni(launcher.LanguagePackSupport));
         WriteKv(sb, "languagepackfirstrundone", langPackFirstRun);
         WriteKv(sb, "automaticlanguagepackupdates", BoolToIni(launcher.AutomaticLanguagePackUpdates));
         WriteKv(sb, "activelanguagepacks",       string.Join('|', launcher.ActiveLanguagePacks));
@@ -347,9 +344,6 @@ public class ConfigService
 
     public void SaveBannerCollapsed(bool value) =>
         UpdateIniValue(ConfigPath(), "launcher", "bannercollapsed", BoolToIni(value));
-
-    public void SaveLanguagePackSupport(bool value) =>
-        UpdateIniValue(ConfigPath(), "launcher", "languagepacksupport", BoolToIni(value));
 
     public void SaveLanguagePackFirstRunDone(bool value) =>
         UpdateIniValue(ConfigPath(), "launcher", "languagepackfirstrundone", BoolToIni(value));

--- a/launcher/Services/LanguagePackService.cs
+++ b/launcher/Services/LanguagePackService.cs
@@ -75,17 +75,11 @@ public class LanguagePackService
         EnsureGameModsFolder(installDir);
     }
 
-    public void PrepareRuntime(string installDir, bool enabled)
-    {
-        EnsureFolders(installDir);
-        if (enabled)
-            EnableSupport(installDir);
-        else
-            DisableSupport(installDir);
-    }
+    /// <summary>True when version.dll (the language pack loader) is present in the game folder.</summary>
+    public bool IsSupportInstalled(string installDir) =>
+        !string.IsNullOrWhiteSpace(installDir) && File.Exists(TargetDll(installDir));
 
-    public void CleanupRuntime(string installDir) => DisableSupport(installDir);
-
+    /// <summary>Copies the embedded version.dll into the game folder so active packs load in-game.</summary>
     public void EnableSupport(string installDir)
     {
         EnsureSourceLanguagePacksFolder();
@@ -97,6 +91,7 @@ public class LanguagePackService
         stream.CopyTo(target);
     }
 
+    /// <summary>Removes version.dll from the game folder.</summary>
     public void DisableSupport(string installDir)
     {
         var target = TargetDll(installDir);

--- a/launcher/ViewModels/MainViewModel.cs
+++ b/launcher/ViewModels/MainViewModel.cs
@@ -76,7 +76,6 @@ public partial class MainViewModel : ObservableObject
         Log      = new LogViewModel(processSvc, text2Clipboard);
         Settings = new SettingsViewModel(
             config, version, null, text2Clipboard, cfg, patchSvc, dbSvc, validateSvc, maintenanceSvc, langPackSvc);
-        Settings.CleanupLanguagePackRuntime();
 
         // Startup auto-update check (no-op unless the user enabled it); fire-and-forget, never blocks launch.
         _ = Settings.RunAutomaticUpdatesIfEnabledAsync();
@@ -86,7 +85,6 @@ public partial class MainViewModel : ObservableObject
         Log.CloseApp        += () => Window?.Close();
         Settings.RunRequested += OnRunRequested;
         Settings.OpenUrl      += OpenBrowser;
-        _processSvc.ProcessExited += _ => Settings.CleanupLanguagePackRuntime();
 
         // If autorun, trigger the full run flow (respects DirectLogin, SimultaneousLaunch, etc.)
         if (autoRun)
@@ -239,15 +237,7 @@ public partial class MainViewModel : ObservableObject
         Log.Reset();
         SwitchTo("log");
         Log.UpdateTitle(Version);
-        try
-        {
-            _processSvc.Launch(args);
-        }
-        catch
-        {
-            Settings.CleanupLanguagePackRuntime();
-            throw;
-        }
+        _processSvc.Launch(args);
     }
 
     public void SwitchTo(string view)

--- a/launcher/ViewModels/SettingsViewModel.cs
+++ b/launcher/ViewModels/SettingsViewModel.cs
@@ -34,7 +34,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _communityLogging;
 
     // ── Language Packs ────────────────────────────────────────────────────
-    [ObservableProperty] private bool   _languagePackSupport;
+    // version.dll (the in-game loader) is added/removed on demand via the Install/Remove buttons;
+    // its presence on disk — not a persisted flag — is the source of truth for "support installed".
+    [ObservableProperty] private bool   _languagePackSupportInstalled;
     [ObservableProperty] private bool   _languagePacksLoading;
     [ObservableProperty] private string _languagePackStatus = "";
     [ObservableProperty] private bool   _languagePackStatusIsError;
@@ -100,15 +102,38 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
-    partial void OnLanguagePackSupportChanged(bool value)
+    // version.dll add/remove lives in the Game → Install "Patch" fieldset alongside the launcher/config
+    // patches, so it shares the Patching flag and PatchStatus surface (see RunPatch).
+    public bool CanInstallSupport => DqxDirValid && !LanguagePackSupportInstalled && !Patching;
+    public bool CanRemoveSupport  => DqxDirValid &&  LanguagePackSupportInstalled && !Patching;
+
+    partial void OnLanguagePackSupportInstalledChanged(bool value)
     {
-        try { _cfg.SaveLanguagePackSupport(value); } catch { }
-        SetLanguagePackStatus(value
-            ? "Language pack support enabled. version.dll will be installed when you click Run."
-            : "Language pack support disabled. version.dll will be removed when possible.");
-        if (!value)
-            CleanupLanguagePackRuntime();
+        OnPropertyChanged(nameof(CanInstallSupport));
+        OnPropertyChanged(nameof(CanRemoveSupport));
     }
+
+    private void RefreshLanguagePackSupportInstalled() =>
+        LanguagePackSupportInstalled = DqxDirValid && _languagePacks.IsSupportInstalled(DqxDir);
+
+    [RelayCommand]
+    private Task InstallLanguagePackSupport() => RunPatch(async installDir =>
+    {
+        var fileNames = GetActiveLanguagePackFileNames();
+        await Task.Run(() =>
+        {
+            _languagePacks.EnableSupport(installDir);
+            _languagePacks.RebuildGameModsFromActive(installDir, fileNames);
+        });
+        LanguagePackSupportInstalled = true;
+    });
+
+    [RelayCommand]
+    private Task RemoveLanguagePackSupport() => RunPatch(async installDir =>
+    {
+        await Task.Run(() => _languagePacks.DisableSupport(installDir));
+        LanguagePackSupportInstalled = false;
+    });
 
     [ObservableProperty] private bool _automaticUpdates;
 
@@ -148,8 +173,8 @@ public partial class SettingsViewModel : ObservableObject
             // Reflect new versions/metadata in the list.
             await ScanLanguagePacks();
 
-            // Re-extract into Game\mods if an active pack changed and support is on.
-            if (updatedAnyActive && LanguagePackSupport && DqxDirValid)
+            // Re-extract into Game\mods if an active pack changed and support is installed.
+            if (updatedAnyActive && LanguagePackSupportInstalled && DqxDirValid)
             {
                 var activePacks = LanguagePacks.Where(m => m.IsActive && m.CanActivate).ToList();
                 if (activePacks.Count > 0)
@@ -258,6 +283,9 @@ public partial class SettingsViewModel : ObservableObject
     {
         if (!value && GameSubTab == "launch")
             GameSubTab = "install";
+        RefreshLanguagePackSupportInstalled();
+        OnPropertyChanged(nameof(CanInstallSupport));
+        OnPropertyChanged(nameof(CanRemoveSupport));
     }
 
     partial void OnSimultaneousLaunchChanged(bool value)
@@ -443,6 +471,12 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private long   _patchDownloaded;
     [ObservableProperty] private long   _patchTotal;
 
+    partial void OnPatchingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanInstallSupport));
+        OnPropertyChanged(nameof(CanRemoveSupport));
+    }
+
     // ── Maintenance ───────────────────────────────────────────────────────
     private readonly MaintenanceService _maintenance;
     [ObservableProperty] private bool             _checkingMaintenance    = true;
@@ -583,7 +617,6 @@ public partial class SettingsViewModel : ObservableObject
         _communityLogging  = config.Launcher.CommunityLogging;
         _selectedTheme     = config.Launcher.Theme;
         _characterImage    = LoadCharacterImage(_selectedTheme);
-        _languagePackSupport = config.Launcher.LanguagePackSupport;
         _automaticUpdates    = config.Launcher.AutomaticLanguagePackUpdates;
         foreach (var fileName in config.Launcher.ActiveLanguagePacks)
             _savedActiveLanguagePacks.Add(fileName);
@@ -631,6 +664,8 @@ public partial class SettingsViewModel : ObservableObject
             SetLanguagePackStatus("dqxclarity\\language-packs is ready. Set a valid DQX folder path before activating language packs.");
         }
 
+        _languagePackSupportInstalled = _dqxDirValid && languagePacks.IsSupportInstalled(_dqxDir);
+
         _ = FetchMaintenanceStatus();
 
         _patch.Progress += (downloaded, total) =>
@@ -672,8 +707,15 @@ public partial class SettingsViewModel : ObservableObject
             _nameOverridesLoaded = true;
             _ = LoadNamePairsAsync();
         }
+        else if (tab == "game")
+        {
+            // The version.dll add/remove buttons live in the Patch fieldset; reflect on-disk state
+            // in case the file was changed outside the app.
+            RefreshLanguagePackSupportInstalled();
+        }
         else if (tab == "languagepacks")
         {
+            RefreshLanguagePackSupportInstalled();
             await ScanLanguagePacks();
             // Fire-and-forget first-run default English download so it never blocks the UI.
             _ = EnsureDefaultLanguagePackAsync();
@@ -749,7 +791,6 @@ public partial class SettingsViewModel : ObservableObject
             DirectLogin              = DirectLogin,
             DirectLoginAccountNumber = SelectedAccount?.Number ?? 0,
             Theme                    = SelectedTheme,
-            LanguagePackSupport      = LanguagePackSupport,
             ActiveLanguagePacks      = GetActiveLanguagePackFileNames(),
         };
         var translation = new TranslationConfig
@@ -762,6 +803,10 @@ public partial class SettingsViewModel : ObservableObject
             LibreTranslateUrl  = LibreTranslateUrl,
         };
         try { _cfg.Save(launcherCfg, translation); } catch { }
+
+        // Re-apply the active packs to Game\mods so the current selection is live at launch.
+        // version.dll itself is added/removed manually via the Language tab Install/Remove buttons.
+        ApplyActiveLanguagePacks();
 
         if (DirectLogin)
         {
@@ -801,13 +846,10 @@ public partial class SettingsViewModel : ObservableObject
 
                 try
                 {
-                    if (!PrepareLanguagePackRuntime())
-                        return;
                     new GameLaunchService().Launch(DqxDir, tr.SessionId!, 99);
                 }
                 catch (Exception ex)
                 {
-                    CleanupLanguagePackRuntime();
                     if (ShowInfoRequested != null)
                         await ShowInfoRequested("Launch failed", ex.Message);
                     return;
@@ -849,14 +891,11 @@ public partial class SettingsViewModel : ObservableObject
 
                 try
                 {
-                    if (!PrepareLanguagePackRuntime())
-                        return;
                     var gameLauncher = new GameLaunchService();
                     gameLauncher.Launch(DqxDir, finalResult.SessionId!, SelectedAccount.Number);
                 }
                 catch (Exception ex)
                 {
-                    CleanupLanguagePackRuntime();
                     if (ShowInfoRequested != null)
                         await ShowInfoRequested("Launch failed", ex.Message);
                     return;
@@ -865,17 +904,8 @@ public partial class SettingsViewModel : ObservableObject
         }
         else if (SimultaneousLaunch && !string.IsNullOrEmpty(DqxDir))
         {
-            if (!PrepareLanguagePackRuntime())
-                return;
             try { _cfg.LaunchDqx(DqxDir); }
-            catch
-            {
-                CleanupLanguagePackRuntime();
-            }
-        }
-        else if (!PrepareLanguagePackRuntime())
-        {
-            return;
+            catch { }
         }
 
         var args = new List<string>();
@@ -1088,9 +1118,10 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             _languagePacks.EnsureFolders(DqxDir);
-            SetLanguagePackStatus(LanguagePackSupport
-                ? "Language pack support enabled. version.dll will be installed when you click Run."
-                : "Language pack folders ready.");
+            RefreshLanguagePackSupportInstalled();
+            SetLanguagePackStatus(LanguagePackSupportInstalled
+                ? "Language pack support is installed."
+                : "Language pack folders ready. Add DragonHook on the Game tab to load packs in-game.");
         }
         catch (Exception ex)
         {
@@ -1098,47 +1129,18 @@ public partial class SettingsViewModel : ObservableObject
         }
     }
 
-    public void CleanupLanguagePackRuntime()
+    /// <summary>Best-effort: re-extracts the active packs into Game\mods so the current selection is
+    /// live at launch. No-op without a valid game folder or when support (version.dll) isn't installed.</summary>
+    private void ApplyActiveLanguagePacks()
     {
-        if (!DqxDirValid) return;
-
+        if (!DqxDirValid || !LanguagePackSupportInstalled) return;
         try
         {
-            _languagePacks.CleanupRuntime(DqxDir);
-            if (!LanguagePackSupport)
-                SetLanguagePackStatus("Language pack support disabled.");
-        }
-        catch (Exception ex)
-        {
-            SetLanguagePackStatus($"Could not remove version.dll: {ex.Message}", true);
-        }
-    }
-
-    private bool PrepareLanguagePackRuntime()
-    {
-        if (!DqxDirValid)
-        {
-            if (LanguagePackSupport)
-                SetLanguagePackStatus("Set a valid DQX folder path before using language pack support.", true);
-            return !LanguagePackSupport;
-        }
-
-        try
-        {
-            _languagePacks.PrepareRuntime(DqxDir, LanguagePackSupport);
-            // Unpack the saved active packs into Game\mods now (applies any selection made before
-            // the game folder existed). Reads from the source folder, independent of the UI list.
-            if (LanguagePackSupport)
-                _languagePacks.RebuildGameModsFromActive(DqxDir, GetActiveLanguagePackFileNames());
-            SetLanguagePackStatus(LanguagePackSupport
-                ? "Language pack support active for this run."
-                : "Language pack support disabled.");
-            return true;
+            _languagePacks.RebuildGameModsFromActive(DqxDir, GetActiveLanguagePackFileNames());
         }
         catch (Exception ex)
         {
             SetLanguagePackStatus(ex.Message, true);
-            return false;
         }
     }
 

--- a/launcher/ViewModels/SettingsViewModel.cs
+++ b/launcher/ViewModels/SettingsViewModel.cs
@@ -791,6 +791,7 @@ public partial class SettingsViewModel : ObservableObject
             DirectLogin              = DirectLogin,
             DirectLoginAccountNumber = SelectedAccount?.Number ?? 0,
             Theme                    = SelectedTheme,
+            AutomaticLanguagePackUpdates = AutomaticUpdates,
             ActiveLanguagePacks      = GetActiveLanguagePackFileNames(),
         };
         var translation = new TranslationConfig

--- a/launcher/Views/SettingsView.axaml
+++ b/launcher/Views/SettingsView.axaml
@@ -386,7 +386,7 @@
                                             <Button Classes="ghost" FontSize="11" Padding="2,0" VerticalAlignment="Center" Click="OnPatchHelpClick">?</Button>
                                         </StackPanel>
 
-                                        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto">
+                                        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto">
                                             <Button Grid.Column="0" Grid.Row="0" Margin="0,0,3,0"
                                                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
                                                     Command="{Binding PatchLauncherCommand}" IsEnabled="{Binding !Patching}"
@@ -404,6 +404,15 @@
                                                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
                                                     Command="{Binding RestoreConfigCommand}" IsEnabled="{Binding !Patching}"
                                                     ToolTip.Tip="Restore the original Japanese Config executable.">Restore Config</Button>
+
+                                            <Button Grid.Column="0" Grid.Row="2" Margin="0,4,3,0"
+                                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                                                    Command="{Binding InstallLanguagePackSupportCommand}" IsEnabled="{Binding CanInstallSupport}"
+                                                    ToolTip.Tip="Add DragonHook so active language packs load in-game.">Add DragonHook</Button>
+                                            <Button Grid.Column="1" Grid.Row="2" Margin="3,4,0,0"
+                                                    HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
+                                                    Command="{Binding RemoveLanguagePackSupportCommand}" IsEnabled="{Binding CanRemoveSupport}"
+                                                    ToolTip.Tip="Remove DragonHook from your game folder.">Remove DragonHook</Button>
                                         </Grid>
 
                                         <ProgressBar IsVisible="{Binding Patching}" Minimum="0" Maximum="100">
@@ -732,7 +741,7 @@
 
                 <!-- ══ LANGUAGE PACKS (full height) ═════════════════════ -->
                 <Grid x:Name="PanelLanguagePacks" IsVisible="False" Margin="14,8"
-                      RowDefinitions="Auto,Auto,Auto,*">
+                      RowDefinitions="Auto,Auto,Auto,Auto,*">
 
                     <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,*" Margin="0,0,0,10">
                         <Button Grid.Column="0"
@@ -745,11 +754,7 @@
                                 IsEnabled="{Binding !LanguagePacksLoading}"
                                 ToolTip.Tip="Add a Clarity Language Pack (.clpk) from your computer."
                                 Margin="0,0,10,0">Load from File…</Button>
-                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                            <CheckBox Content="Enable"
-                                      IsChecked="{Binding LanguagePackSupport}"
-                                      VerticalAlignment="Center"
-                                      ToolTip.Tip="Use your active language packs while playing."/>
+                        <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="12" HorizontalAlignment="Right" VerticalAlignment="Center">
                             <CheckBox Content="Automatic updates"
                                       IsChecked="{Binding AutomaticUpdates}"
                                       VerticalAlignment="Center"
@@ -757,14 +762,27 @@
                         </StackPanel>
                     </Grid>
 
-                    <TextBlock Grid.Row="1"
+                    <Border Grid.Row="1"
+                            BorderBrush="{DynamicResource AppDanger}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="8,6"
+                            Margin="0,0,0,8"
+                            IsVisible="{Binding !LanguagePackSupportInstalled}">
+                        <TextBlock Text="DragonHook isn't installed, so your language packs won't load in-game. Add it on the Game → Install Configuration tab (Patch → Add DragonHook)."
+                                   FontSize="11"
+                                   Foreground="{DynamicResource AppDanger}"
+                                   TextWrapping="Wrap"/>
+                    </Border>
+
+                    <TextBlock Grid.Row="2"
                                Text="{Binding LanguagePackStatus}"
                                FontSize="11"
                                Foreground="{DynamicResource AppMuted}"
                                TextWrapping="Wrap"
                                Margin="0,0,0,8"
                                IsVisible="{Binding !LanguagePackStatusIsError}"/>
-                    <TextBlock Grid.Row="1"
+                    <TextBlock Grid.Row="2"
                                Text="{Binding LanguagePackStatus}"
                                FontSize="11"
                                Foreground="{DynamicResource AppDanger}"
@@ -772,7 +790,7 @@
                                Margin="0,0,0,8"
                                IsVisible="{Binding LanguagePackStatusIsError}"/>
 
-                    <Border Grid.Row="2"
+                    <Border Grid.Row="3"
                             BorderBrush="{DynamicResource AppBorder}"
                             BorderThickness="1"
                             CornerRadius="4"
@@ -808,7 +826,7 @@
                         </StackPanel>
                     </Border>
 
-                    <Border Grid.Row="3"
+                    <Border Grid.Row="4"
                             BorderBrush="{DynamicResource AppBorder}"
                             BorderThickness="1"
                             CornerRadius="4"

--- a/launcher/Views/SettingsView.axaml.cs
+++ b/launcher/Views/SettingsView.axaml.cs
@@ -99,7 +99,10 @@ public partial class SettingsView : UserControl
         "Swaps the DQX launcher executable with an English-patched version, or restores the original Japanese file. " +
         "This only affects the launcher window's UI text and has no impact on gameplay.\n\n" +
         "Patch Config / Restore Config\n" +
-        "Same as above but for DQXConfig.exe - patches or restores the configuration tool's interface text.";
+        "Same as above but for DQXConfig.exe - patches or restores the configuration tool's interface text.\n\n" +
+        "Add DragonHook / Remove DragonHook\n" +
+        "Adds or removes the language pack loader (DragonHook) in your game folder. It stays in place until you remove it - " +
+        "active language packs only load in-game while it's present.";
 
     public SettingsView()
     {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -98,4 +98,4 @@ The launcher scans the `dqxclarity/language-packs` folder for `*.clpk` (and `*.z
 - Use `git status` before and after changes.
 - The launcher is C#/.NET 9 Avalonia; the in-game engine is Python plus Frida hooks.
 - The launcher expects the Python app files near the exe in the final packaged folder.
-- `launcher/native/version.dll` is the dragonhook proxy DLL, embedded in the launcher and installed into the game only while language pack support is enabled.
+- `launcher/native/version.dll` is the dragonhook proxy DLL, embedded in the launcher and added to / removed from the game folder on demand via the Language tab's Install/Remove support buttons (its presence on disk is what enables language packs in-game).


### PR DESCRIPTION
## What

Reworks how the language pack loader (`version.dll`) gets into the game folder. Instead of injecting it on **Run** and pulling it out when the game process exits, it's now added/removed by explicit buttons — matching the existing **Patch/Restore Launcher** and **Patch/Restore Config** workflow.

It's also renamed to **DragonHook** everywhere the user sees it.

## Why

The inject-on-start / remove-on-exit lifecycle was fragile and surprising. Treating the loader like the other game-folder patches (a thing you add once and it stays until you remove it) is simpler to reason about and consistent with the rest of the Patch fieldset.

## Changes

- **Manual buttons** — `Add DragonHook` / `Remove DragonHook` added as a third row in the Game → Install Configuration **Patch** fieldset. They reuse the existing `RunPatch` flow, so they share the `Patching` flag, status line, and "Done!" confirmation. Add is enabled only when the loader is absent, Remove only when present; both require a valid DQX folder.
- **File presence is the source of truth** — dropped the persisted `languagepacksupport` config flag (`AppConfig`, `ConfigService` load/save/setter). Installed state is now derived from whether `version.dll` exists in the game folder, refreshed on tab entry and DQX-dir changes.
- **Removed the auto lifecycle** — no more `PrepareLanguagePackRuntime`/`CleanupLanguagePackRuntime` from the Run branches, the startup cleanup, the `ProcessExited` cleanup, or the cleanup-on-launch-failure. Run now just re-applies active packs to `Game\mods` (when DragonHook is installed) and launches.
- **Rename to DragonHook** in all user-facing text (button labels, tooltips, Patch help dialog, Language-tab status). The on-disk filename, embedded resource (`LogicalName=version.dll`), and `Game\version.dll` path are unchanged — the game loads the proxy by that literal name.
- **Warning banner** — the Language tab now shows a red banner when DragonHook isn't installed, so activating packs that won't load in-game is no longer silent.

## Behavior changes worth noting

- DragonHook now **persists** across sessions until explicitly removed (the point of the change).
- It is **no longer auto-installed on first run** — a user must click **Add DragonHook** once. The new warning banner surfaces this.

## Notes for reviewers

- The warning banner shows whenever DragonHook is absent, including before a valid DQX folder is set (where it can't be added yet). The message points to the same Game tab where the folder is configured. Easy to gate on `DqxDirValid` if preferred.
- Old configs with a leftover `languagepacksupport=` key are ignored harmlessly.

Build: `dotnet build` succeeds with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)